### PR TITLE
Complete XFusion Guardian v0.1 roadmap

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -15,11 +15,11 @@ The current implementation includes:
 - interaction states
 - deterministic policy engine
 - context-aware risk classification
-- short-lived session memory
+- short-lived graph state for active plans
 - typed confirmation boundaries
 - scoped tool router
 - verification flow
-- append-only JSONL audit traces
+- append-only JSONL audit traces via `XFUSION_AUDIT_LOG_PATH`
 - CLI entrypoint
 - OpenAI-compatible LLM client scaffold
 
@@ -66,29 +66,30 @@ Submission and demo docs:
 
 Agent architecture docs:
 
-- [docs/architecture/pydantic-langgraph-blueprint.md](docs/architecture/pydantic-langgraph-blueprint.md): post-v0.1 target architecture using Pydantic v2 and LangGraph.
+- [docs/architecture/pydantic-langgraph-blueprint.md](docs/architecture/pydantic-langgraph-blueprint.md): current Pydantic v2 + LangGraph architecture and next-step blueprint.
 - [docs/tools.md](docs/tools.md): v0.1 tool surface and guarantees.
 - [docs/prompts/core-agent-prompt.md](docs/prompts/core-agent-prompt.md): documented LLM boundary and core agent prompt.
 
 Core code:
 
-- [xfusion/models.py](xfusion/models.py): execution plans, steps, states, and response models.
-- [xfusion/agent.py](xfusion/agent.py): adaptive agent loop.
-- [xfusion/planner.py](xfusion/planner.py): request-to-plan construction.
-- [xfusion/parser.py](xfusion/parser.py): deterministic v0.1 intent parsing.
-- [xfusion/policy.py](xfusion/policy.py): deterministic risk policy.
-- [xfusion/environment.py](xfusion/environment.py): Linux environment sensing model.
-- [xfusion/tools.py](xfusion/tools.py): scoped tool router and verification hooks.
-- [xfusion/memory.py](xfusion/memory.py): short-lived session memory.
-- [xfusion/audit.py](xfusion/audit.py): JSONL audit trace writer.
-- [xfusion/cli.py](xfusion/cli.py): CLI entrypoint and response formatting.
-- [xfusion/llm.py](xfusion/llm.py): OpenAI-compatible client scaffold.
+- [xfusion/domain/models](xfusion/domain/models): Pydantic contracts for plans, environment, policy, verification, audit, and scenarios.
+- [xfusion/graph](xfusion/graph): LangGraph state, nodes, wiring, response formatting, and audit event helpers.
+- [xfusion/policy](xfusion/policy): deterministic policy, protected path checks, and confirmation helpers.
+- [xfusion/tools](xfusion/tools): scoped typed tools for system, disk, file, process, user, and cleanup operations.
+- [xfusion/audit](xfusion/audit): JSONL audit trace writer.
+- [xfusion/app/cli.py](xfusion/app/cli.py): CLI entrypoint.
+- [xfusion/llm/client.py](xfusion/llm/client.py): OpenAI-compatible client scaffold.
 
 Tests:
 
-- [tests/test_core_contracts.py](tests/test_core_contracts.py): planning, policy, memory, audit, and workflow contracts.
-- [tests/test_cli_contracts.py](tests/test_cli_contracts.py): CLI response contract.
-- [tests/test_verification_suite.py](tests/test_verification_suite.py): YAML scenario schema and static/fake-tool verification checks.
+- [tests/test_smoke.py](tests/test_smoke.py): CLI and graph smoke tests.
+- [tests/test_plan_correctness.py](tests/test_plan_correctness.py): plan shape, dependency, refusal, and abort behavior.
+- [tests/test_data_flow.py](tests/test_data_flow.py): step-output data flow across workflows.
+- [tests/test_safety_invariants.py](tests/test_safety_invariants.py): confirmation and verification invariants.
+- [tests/test_response_and_audit_contract.py](tests/test_response_and_audit_contract.py): judge response contract and JSONL audit persistence.
+- [tests/test_workflow_completion.py](tests/test_workflow_completion.py): demo workflow completion tests.
+- [tests/test_verification_runner.py](tests/test_verification_runner.py): YAML scenario static/fake-tool checks.
+- [tests/test_live_vm_rehearsal.py](tests/test_live_vm_rehearsal.py): opt-in Lima/live-session rehearsal smoke.
 
 ## Architecture Invariants
 
@@ -139,6 +140,19 @@ Context matters. For example, bounded log cleanup can be more reasonable under h
 - Docker is acceptable for development smoke tests only, not for the official demo.
 
 The current parser is deterministic for v0.1 stability. If wiring in LLM-based parsing, keep the deterministic policy and tool authorization boundary intact.
+
+## Roadmap Status
+
+| Area | Status |
+| --- | --- |
+| Pydantic + LangGraph control loop | implemented |
+| Exact typed confirmation | implemented |
+| Mandatory verification | implemented |
+| Persistent JSONL audit logs | implemented |
+| Seven-scenario demo spine | implemented |
+| Safe cleanup | implemented with limitations: approved demo/temp candidates only |
+| Live VM rehearsal | implemented with limitations: opt-in smoke test, not default |
+| SSH/web/voice/persistent memory/multi-agent orchestration | future |
 
 ## Development Workflow
 

--- a/README.md
+++ b/README.md
@@ -161,6 +161,15 @@ the dangerous decisions inspectable and controllable.
 
 ## Status
 
-v0.1 baseline is implemented and tested. The post-v0.1 direction is documented
-in the Pydantic + LangGraph architecture blueprint; future work should migrate
-incrementally while preserving the verification suite and safety invariants.
+v0.1 judge-ready demo spine is implemented and tested. The Pydantic + LangGraph
+architecture blueprint documents the current baseline plus future refinements.
+
+| Area | Status |
+| --- | --- |
+| Explicit plan-executing graph | implemented |
+| Deterministic policy and exact confirmation | implemented |
+| Persistent JSONL audit logs | implemented |
+| Seven acceptance demo scenarios | implemented |
+| Safe cleanup | implemented with limitations: approved demo/temp candidates only |
+| Live VM rehearsal | implemented with limitations: opt-in, skipped by default |
+| SSH, web UI, voice, persistent memory, multi-agent orchestration | future |

--- a/docs/architecture/pydantic-langgraph-blueprint.md
+++ b/docs/architecture/pydantic-langgraph-blueprint.md
@@ -1,8 +1,8 @@
 # Pydantic v2 + LangGraph Architecture Blueprint
 
-This document defines the target architecture for evolving XFusion from the current dataclass/custom-loop v0.1 into a **Pydantic v2 + LangGraph-first architecture**, with LangChain used only as optional integration glue.
+This document defines the current and target architecture for XFusion's **Pydantic v2 + LangGraph-first architecture**, with LangChain used only as optional integration glue.
 
-This is a post-v0.1 blueprint. It does not describe the current implementation one-to-one, and it should not be treated as a refactor already completed.
+The v0.1 implementation now uses this stack. Some sections below remain blueprint-level guidance for future refinements, but the package layout, core contracts, and graph loop are the current baseline.
 
 ## References
 
@@ -633,7 +633,7 @@ def run_fake_tool_scenario(scenario: VerificationScenario) -> ScenarioResult:
     ...
 ```
 
-## Migration Mapping
+## Historical Migration Mapping
 
 | Current file | Target location |
 | --- | --- |
@@ -699,4 +699,3 @@ Each step must preserve:
 - Do not add graph persistence during the first orchestration refactor.
 - Do not broaden shell execution beyond registered typed tools.
 - Do not move to a web UI as part of this architecture migration.
-

--- a/docs/sandbox-lima.md
+++ b/docs/sandbox-lima.md
@@ -37,7 +37,16 @@ export XFUSION_AUDIT_LOG_PATH=audit.jsonl
 uv run xfusion
 ```
 
+## Run Opt-In Rehearsal Smoke
+
+Inside the VM:
+
+```bash
+XFUSION_RUN_LIVE_VM=1 uv run pytest tests/test_live_vm_rehearsal.py -q
+```
+
+The live rehearsal is skipped by default outside this explicit opt-in.
+
 ## Fallback
 
 If Lima setup fails, Multipass Ubuntu is acceptable. Docker is acceptable only for development smoke tests, not for the official demo, because container behavior differs from a real server OS for systemd, sudo, users, and process management.
-

--- a/docs/self-test.md
+++ b/docs/self-test.md
@@ -13,7 +13,7 @@ uv run ty check
 ## Verification Scenario Suite
 
 ```bash
-uv run pytest tests/test_verification_suite.py -q
+uv run pytest tests/test_verification_runner.py -q
 ```
 
 Expected:
@@ -36,6 +36,16 @@ Expected:
 - Response contains risk reasoning.
 - Response contains verification.
 - `audit.jsonl` receives a trace record unless `XFUSION_AUDIT_LOG_PATH` is changed.
+
+## Opt-In Lima Rehearsal
+
+Run only inside the Lima Ubuntu demo VM or another intentional live Linux session:
+
+```bash
+XFUSION_RUN_LIVE_VM=1 uv run pytest tests/test_live_vm_rehearsal.py -q
+```
+
+Default tests skip this module so local development never performs live VM rehearsal accidentally.
 
 ## Safety Smoke Tests
 

--- a/docs/verification-suite.md
+++ b/docs/verification-suite.md
@@ -105,7 +105,7 @@ expected:
 ## Run
 
 ```bash
-uv run pytest tests/test_verification_suite.py -q
+uv run pytest tests/test_verification_runner.py -q
 ```
 
 Full project verification remains:
@@ -117,5 +117,8 @@ uv run ruff format --check .
 uv run ty check
 ```
 
-Live VM rehearsal is documented separately and should only be run intentionally inside the Lima Ubuntu demo environment.
+Live VM rehearsal is documented separately and should only be run intentionally inside the Lima Ubuntu demo environment:
 
+```bash
+XFUSION_RUN_LIVE_VM=1 uv run pytest tests/test_live_vm_rehearsal.py -q
+```

--- a/tests/test_live_vm_rehearsal.py
+++ b/tests/test_live_vm_rehearsal.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    os.environ.get("XFUSION_RUN_LIVE_VM") != "1",
+    reason="Live Lima VM rehearsal is opt-in; set XFUSION_RUN_LIVE_VM=1.",
+)
+
+
+def test_live_vm_rehearsal_command_smoke() -> None:
+    """Run a minimal CLI smoke check in an explicitly opted-in VM/session."""
+    result = subprocess.run(
+        ["uv", "run", "xfusion"],
+        input="check disk usage\nexit\n",
+        capture_output=True,
+        text=True,
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 0
+    assert "Intent:" in result.stdout
+    assert "Verification:" in result.stdout
+    assert "Disk usage" in result.stdout

--- a/tests/test_response_and_audit_contract.py
+++ b/tests/test_response_and_audit_contract.py
@@ -89,6 +89,22 @@ def test_jsonl_audit_file_receives_step_records(tmp_path) -> None:
     assert record["status"] == "success"
 
 
+def test_jsonl_audit_file_receives_refusal_records(tmp_path) -> None:
+    audit_path = tmp_path / "audit.jsonl"
+    state = make_graph_state("Delete everything in /etc", audit_log_path=str(audit_path))
+
+    assert state["plan"].interaction_state == InteractionState.REFUSED
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert lines
+
+    record = json.loads(lines[-1])
+    assert record["plan_id"] == state["plan"].plan_id
+    assert record["step_id"] == "delete_path"
+    assert record["action_taken"]["tool"] == "cleanup.safe_disk_cleanup"
+    assert record["status"] == "refused"
+    assert "protected" in record["summary"].lower()
+
+
 def test_audit_logger_writes_required_schema(tmp_path) -> None:
     sink = JsonlAuditSink(str(tmp_path / "manual.jsonl"))
     logger = AuditLogger(sink)

--- a/tests/test_response_and_audit_contract.py
+++ b/tests/test_response_and_audit_contract.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from typing import Any
+
+from xfusion.audit.jsonl_sink import JsonlAuditSink
+from xfusion.audit.logger import AuditLogger
+from xfusion.domain.enums import InteractionState
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.execution.command_runner import CommandRunner
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.tools.disk import DiskTools
+from xfusion.tools.process import ProcessTools
+from xfusion.tools.registry import ToolRegistry
+from xfusion.tools.system import SystemTools
+
+
+def make_graph_state(user_input: str, audit_log_path: str | None = None) -> dict[str, Any]:
+    runner = CommandRunner()
+    system_tools = SystemTools(runner)
+    registry = ToolRegistry(system_tools, DiskTools(runner), ProcessTools(runner))
+    graph = build_agent_graph(registry).compile()
+
+    state: dict[str, Any] = {
+        "user_input": user_input,
+        "environment": EnvironmentState(distro_family="ubuntu", sudo_available=True),
+        "language": "en",
+        "plan": None,
+        "current_step_id": None,
+        "policy_decision": None,
+        "verification_result": None,
+        "last_tool_output": None,
+        "step_outputs": {},
+        "pending_confirmation_phrase": None,
+        "response": "",
+        "audit_records": [],
+        "audit_log_path": audit_log_path,
+    }
+    return graph.invoke(state)
+
+
+def assert_response_contract(response: str) -> None:
+    required_labels = [
+        "Intent:",
+        "Environment:",
+        "Plan:",
+        "Risk:",
+        "Action:",
+        "Verification:",
+        "State:",
+        "Next:",
+    ]
+    for label in required_labels:
+        assert label in response
+
+
+def test_success_response_contains_judge_contract_sections() -> None:
+    state = make_graph_state("check disk usage")
+
+    assert state["plan"].interaction_state == InteractionState.COMPLETED
+    assert_response_contract(state["response"])
+    assert "disk" in state["response"].lower()
+
+
+def test_refusal_response_contains_judge_contract_sections() -> None:
+    state = make_graph_state("Delete everything in /etc")
+
+    assert state["plan"].interaction_state == InteractionState.REFUSED
+    assert_response_contract(state["response"])
+    assert "/etc" in state["response"]
+    assert "protected" in state["response"].lower()
+
+
+def test_jsonl_audit_file_receives_step_records(tmp_path) -> None:
+    audit_path = tmp_path / "audit.jsonl"
+    state = make_graph_state("check disk usage", audit_log_path=str(audit_path))
+
+    assert state["plan"].interaction_state == InteractionState.COMPLETED
+    lines = audit_path.read_text(encoding="utf-8").splitlines()
+    assert lines
+
+    record = json.loads(lines[-1])
+    assert record["plan_id"] == state["plan"].plan_id
+    assert record["step_id"] == "check_disk"
+    assert record["before_state"]
+    assert record["action_taken"]
+    assert record["after_state"]
+    assert record["verification_result"]["success"] is True
+    assert record["status"] == "success"
+
+
+def test_audit_logger_writes_required_schema(tmp_path) -> None:
+    sink = JsonlAuditSink(str(tmp_path / "manual.jsonl"))
+    logger = AuditLogger(sink)
+
+    logger.log_step(
+        plan_id="plan",
+        step_id="step",
+        interaction_state="completed",
+        before_state={"before": True},
+        action_taken={"tool": "disk.check_usage"},
+        after_state={"after": True},
+        verification_result={"success": True},
+        status="success",
+        summary="ok",
+    )
+
+    record = json.loads((tmp_path / "manual.jsonl").read_text(encoding="utf-8"))
+    assert record["before_state"] == {"before": True}
+    assert record["action_taken"] == {"tool": "disk.check_usage"}

--- a/tests/test_workflow_completion.py
+++ b/tests/test_workflow_completion.py
@@ -1,0 +1,149 @@
+from __future__ import annotations
+
+from typing import Any
+
+from xfusion.domain.enums import InteractionState
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.execution.command_runner import CommandRunner
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.tools.base import ToolOutput
+from xfusion.tools.cleanup import CleanupTools
+
+
+class WorkflowRegistry:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.cleanup_executed = False
+
+    def execute(self, name: str, parameters: dict[str, Any]) -> ToolOutput:
+        self.calls.append((name, parameters))
+        if name == "disk.check_usage":
+            return ToolOutput(summary="Disk usage: 94% full.", data={"usage_percent": 94})
+        if name == "disk.find_large_directories":
+            return ToolOutput(
+                summary="Found demo cache.", data={"items": ["/tmp/xfusion-demo-big"]}
+            )
+        if name == "cleanup.safe_disk_cleanup":
+            if parameters.get("execute") is True:
+                self.cleanup_executed = True
+                return ToolOutput(
+                    summary="Deleted 1 safe cleanup candidate.",
+                    data={
+                        "deleted": ["/tmp/xfusion-demo-big"],
+                        "reclaimed_bytes": 1024,
+                        "ok": True,
+                    },
+                )
+            return ToolOutput(
+                summary="Previewed 1 safe cleanup candidate.",
+                data={
+                    "previewed_candidates": [{"path": "/tmp/xfusion-demo-big", "size_bytes": 1024}],
+                    "reclaimed_bytes": 0,
+                    "ok": True,
+                },
+            )
+        if name == "file.preview_metadata":
+            return ToolOutput(
+                summary="Previewed metadata.", data={"exists": True, "path": "README.md"}
+            )
+        if name == "user.create":
+            return ToolOutput(
+                summary="Created user demoagent.", data={"username": "demoagent", "exists": True}
+            )
+        return ToolOutput(summary=f"Unexpected tool {name}.", data={"error": "unexpected"})
+
+
+def invoke(user_input: str, registry: WorkflowRegistry) -> dict[str, Any]:
+    graph = build_agent_graph(registry).compile()
+    return graph.invoke(
+        {
+            "user_input": user_input,
+            "environment": EnvironmentState(
+                distro_family="ubuntu",
+                sudo_available=True,
+                disk_pressure="high",
+                package_manager="apt",
+            ),
+            "language": "en",
+            "plan": None,
+            "current_step_id": None,
+            "policy_decision": None,
+            "verification_result": None,
+            "last_tool_output": None,
+            "step_outputs": {},
+            "pending_confirmation_phrase": None,
+            "response": "",
+            "audit_records": [],
+        }
+    )
+
+
+def test_file_metadata_preview_workflow() -> None:
+    registry = WorkflowRegistry()
+    state = invoke("Preview metadata for README.md", registry)
+
+    assert state["plan"].interaction_state == InteractionState.COMPLETED
+    assert [name for name, _ in registry.calls] == ["file.preview_metadata"]
+    assert "file.preview_metadata" in state["response"]
+
+
+def test_user_create_requires_confirmation_then_verifies() -> None:
+    registry = WorkflowRegistry()
+    state = invoke("Create user demoagent.", registry)
+
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    assert registry.calls == []
+
+    state["user_input"] = state["pending_confirmation_phrase"]
+    state = build_agent_graph(registry).compile().invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.COMPLETED
+    assert [name for name, _ in registry.calls] == ["user.create"]
+    assert state["verification_result"].success is True
+
+
+def test_disk_pressure_wow_workflow_previews_confirms_cleans_and_verifies() -> None:
+    registry = WorkflowRegistry()
+    state = invoke("The disk feels full. Help me clean it safely.", registry)
+
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    assert [name for name, _ in registry.calls] == [
+        "disk.check_usage",
+        "disk.find_large_directories",
+        "cleanup.safe_disk_cleanup",
+    ]
+    assert registry.calls[-1][1]["execute"] is False
+    assert registry.cleanup_executed is False
+
+    state["user_input"] = state["pending_confirmation_phrase"]
+    state = build_agent_graph(registry).compile().invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.COMPLETED
+    assert [name for name, _ in registry.calls] == [
+        "disk.check_usage",
+        "disk.find_large_directories",
+        "cleanup.safe_disk_cleanup",
+        "cleanup.safe_disk_cleanup",
+        "disk.check_usage",
+    ]
+    assert registry.calls[3][1]["execute"] is True
+    assert registry.cleanup_executed is True
+    assert "preventive" in state["response"].lower() or "monitor" in state["response"].lower()
+
+
+def test_cleanup_tool_previews_before_deleting_and_refuses_protected_path(tmp_path) -> None:
+    demo_file = tmp_path / "xfusion-demo-file"
+    demo_file.write_text("safe demo data", encoding="utf-8")
+    tools = CleanupTools(CommandRunner())
+
+    protected = tools.safe_disk_cleanup(approved_paths=["/etc"], execute=True)
+    assert "error" in protected.data
+    assert demo_file.exists()
+
+    preview = tools.safe_disk_cleanup(approved_paths=[str(tmp_path)], execute=False)
+    assert preview.data["previewed_candidates"]
+    assert demo_file.exists()
+
+    deleted = tools.safe_disk_cleanup(approved_paths=[str(tmp_path)], execute=True)
+    assert deleted.data["deleted"]
+    assert not demo_file.exists()

--- a/verification/README.md
+++ b/verification/README.md
@@ -59,6 +59,11 @@ expected:
 ## Run
 
 ```bash
-uv run pytest tests/test_verification_suite.py -q
+uv run pytest tests/test_verification_runner.py -q
 ```
 
+Opt-in live rehearsal:
+
+```bash
+XFUSION_RUN_LIVE_VM=1 uv run pytest tests/test_live_vm_rehearsal.py -q
+```

--- a/verification/scenarios/gold_demo.yaml
+++ b/verification/scenarios/gold_demo.yaml
@@ -155,13 +155,18 @@
   safe_for_live_execution: true
   notes: "Acceptance demo scenario 7 wow workflow, static planning layer."
   expected:
-    plan_length: 1
-    plan_tools: ["cleanup.safe_disk_cleanup"]
+    plan_length: 5
+    plan_tools:
+      - "disk.check_usage"
+      - "disk.find_large_directories"
+      - "cleanup.safe_disk_cleanup"
+      - "cleanup.safe_disk_cleanup"
+      - "disk.check_usage"
     executed_tools: []
     risk_level: medium
     interaction_state: awaiting_confirmation
     requires_confirmation: true
-    verification_method: filesystem_metadata_recheck
+    verification_method: state_re_read
     verification_outcome: cleanup_candidates_previewed
     final_status: awaiting_confirmation
     outcome_contains: ["cleanup"]

--- a/xfusion/app/cli.py
+++ b/xfusion/app/cli.py
@@ -13,7 +13,7 @@ from xfusion.tools.system import SystemTools
 
 def main() -> None:
     """XFusion Guardian CLI Entrypoint."""
-    load_settings()
+    settings = load_settings()
     runner = CommandRunner()
 
     system_tools = SystemTools(runner)
@@ -45,6 +45,7 @@ def main() -> None:
         "pending_confirmation_phrase": None,
         "response": "",
         "audit_records": [],
+        "audit_log_path": settings.audit_log_path,
     }
 
     while True:

--- a/xfusion/graph/auditing.py
+++ b/xfusion/graph/auditing.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+from xfusion.audit.jsonl_sink import JsonlAuditSink
+from xfusion.audit.logger import AuditLogger
+from xfusion.domain.models.execution_plan import PlanStep
+from xfusion.graph.state import AgentGraphState
+
+
+def log_graph_event(
+    state: AgentGraphState,
+    *,
+    step: PlanStep,
+    status: str,
+    summary: str,
+    action_taken: dict[str, object] | None = None,
+    verification_result: dict[str, object] | None = None,
+) -> None:
+    """Append an in-memory and optional JSONL audit event."""
+    if not state.plan:
+        return
+
+    before_state = state.environment.model_dump()
+    if action_taken is not None:
+        action = action_taken
+    else:
+        action = dict[str, object](
+            {
+                "tool": step.tool,
+                "parameters": step.parameters,
+                "output": state.step_outputs.get(step.step_id, {}),
+            }
+        )
+    after_state: dict[str, object] = {
+        "plan_status": state.plan.status,
+        "step_status": step.status,
+    }
+    verification = verification_result or (
+        state.verification_result.model_dump() if state.verification_result else {}
+    )
+
+    record = {
+        "timestamp": datetime.now().isoformat(),
+        "plan_id": state.plan.plan_id,
+        "step_id": step.step_id,
+        "interaction_state": state.plan.interaction_state,
+        "before_state": before_state,
+        "action_taken": action,
+        "after_state": after_state,
+        "verification_result": verification,
+        "status": status,
+        "summary": summary,
+    }
+    state.audit_records.append(record)
+
+    if state.audit_log_path:
+        AuditLogger(JsonlAuditSink(state.audit_log_path)).log_step(
+            plan_id=state.plan.plan_id,
+            step_id=step.step_id,
+            interaction_state=str(state.plan.interaction_state),
+            before_state=before_state,
+            action_taken=action,
+            after_state=after_state,
+            verification_result=verification,
+            status=status,
+            summary=summary,
+        )

--- a/xfusion/graph/nodes/confirm.py
+++ b/xfusion/graph/nodes/confirm.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from xfusion.domain.enums import InteractionState
+from xfusion.graph.auditing import log_graph_event
 from xfusion.graph.state import AgentGraphState
 
 
@@ -20,11 +21,14 @@ def confirm_node(state: AgentGraphState) -> AgentGraphState:
         state.plan.interaction_state = InteractionState.EXECUTING
         step.requires_confirmation = False
         state.response = "Confirmation received. Proceeding..."
+        log_graph_event(state, step=step, status="confirmed", summary=state.response)
     else:
         state.plan.interaction_state = InteractionState.ABORTED
+        state.plan.status = "aborted"
         state.response = (
             f"Action aborted: Input did not match required confirmation phrase '{expected}'."
         )
+        log_graph_event(state, step=step, status="aborted", summary=state.response)
 
     # Requirements: Confirmation must be cleared after one use.
     state.pending_confirmation_phrase = None

--- a/xfusion/graph/nodes/plan.py
+++ b/xfusion/graph/nodes/plan.py
@@ -46,21 +46,86 @@ def plan_node(state: AgentGraphState) -> AgentGraphState:
                 fallback_action="Report failure and stop.",
             )
         )
-    elif ("disk" in user_input and "clean" in user_input) or (
+    elif ("disk" in user_input and ("clean" in user_input or "full" in user_input)) or (
         "磁盘" in user_input and "清" in user_input
     ):
-        steps.append(
-            PlanStep(
-                step_id="preview_safe_cleanup",
-                intent="Preview safe disk cleanup candidates.",
-                tool="cleanup.safe_disk_cleanup",
-                parameters={"path": "/tmp"},
-                expected_output="Bounded cleanup candidates are previewed.",
-                verification_method="filesystem_metadata_recheck",
-                success_condition="Cleanup candidates are previewed before deletion.",
-                failure_condition="Cleanup candidates cannot be previewed safely.",
-                fallback_action="Report failure and stop.",
-            )
+        cleanup_paths = ["/tmp", "/var/tmp"]
+        steps.extend(
+            [
+                PlanStep(
+                    step_id="check_disk_pressure",
+                    intent="Check disk pressure before cleanup.",
+                    tool="disk.check_usage",
+                    parameters={"path": "/"},
+                    expected_output="Disk usage and pressure are reported.",
+                    verification_method="state_re_read",
+                    success_condition="Disk usage is reported.",
+                    failure_condition="Could not check disk pressure.",
+                    fallback_action="Report failure and stop.",
+                ),
+                PlanStep(
+                    step_id="find_large_candidates",
+                    intent="Identify bounded cleanup contributors.",
+                    tool="disk.find_large_directories",
+                    parameters={"path": "/tmp", "limit": 10},
+                    dependencies=["check_disk_pressure"],
+                    expected_output="Candidate contributors are listed.",
+                    verification_method="filesystem_metadata_recheck",
+                    success_condition="Large directory scan returns bounded results.",
+                    failure_condition="Large directory scan fails.",
+                    fallback_action="Continue with safe demo-cache preview.",
+                ),
+                PlanStep(
+                    step_id="preview_safe_cleanup",
+                    intent="Preview safe cleanup candidates.",
+                    tool="cleanup.safe_disk_cleanup",
+                    parameters={
+                        "approved_paths": cleanup_paths,
+                        "candidate_class": "demo_cache",
+                        "older_than_days": 0,
+                        "max_files": 20,
+                        "max_bytes": 50_000_000,
+                        "execute": False,
+                    },
+                    dependencies=["find_large_candidates"],
+                    expected_output="Bounded cleanup candidates are previewed.",
+                    verification_method="filesystem_metadata_recheck",
+                    success_condition="Cleanup candidates are previewed before deletion.",
+                    failure_condition="Cleanup candidates cannot be previewed safely.",
+                    fallback_action="Report failure and stop.",
+                ),
+                PlanStep(
+                    step_id="execute_safe_cleanup",
+                    intent="Delete only approved previewed cleanup candidates.",
+                    tool="cleanup.safe_disk_cleanup",
+                    parameters={
+                        "approved_paths": cleanup_paths,
+                        "candidate_class": "demo_cache",
+                        "older_than_days": 0,
+                        "max_files": 20,
+                        "max_bytes": 50_000_000,
+                        "execute": True,
+                    },
+                    dependencies=["preview_safe_cleanup"],
+                    expected_output="Approved cleanup candidates are deleted.",
+                    verification_method="command_exit_status_plus_state",
+                    success_condition="Cleanup reports deleted candidates or safe no-op.",
+                    failure_condition="Cleanup execution fails.",
+                    fallback_action="Abort and preserve remaining files.",
+                ),
+                PlanStep(
+                    step_id="verify_disk_after_cleanup",
+                    intent="Verify disk state after cleanup.",
+                    tool="disk.check_usage",
+                    parameters={"path": "/"},
+                    dependencies=["execute_safe_cleanup"],
+                    expected_output="Disk usage is re-read after cleanup.",
+                    verification_method="state_re_read",
+                    success_condition="Disk usage is reported after cleanup.",
+                    failure_condition="Could not verify disk state after cleanup.",
+                    fallback_action="Report cleanup result with verification warning.",
+                ),
+            ]
         )
     elif "disk" in user_input or "磁盘" in user_input or "空间" in user_input:
         steps.append(
@@ -88,6 +153,21 @@ def plan_node(state: AgentGraphState) -> AgentGraphState:
                 success_condition="RAM usage is reported.",
                 failure_condition="Could not check RAM usage.",
                 fallback_action="Report failure and stop.",
+            )
+        )
+    elif "preview metadata for" in user_input:
+        path = state.user_input.split("for", 1)[1].strip(" .") or "."
+        steps.append(
+            PlanStep(
+                step_id="preview_metadata",
+                intent=f"Preview metadata for {path}.",
+                tool="file.preview_metadata",
+                parameters={"path": path},
+                expected_output="Path metadata without file contents.",
+                verification_method="filesystem_metadata_recheck",
+                success_condition="Metadata preview returns existence and path facts.",
+                failure_condition="Metadata preview fails.",
+                fallback_action="Ask for an exact path.",
             )
         )
     elif "search for" in user_input or "find files named" in user_input:

--- a/xfusion/graph/nodes/policy.py
+++ b/xfusion/graph/nodes/policy.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from xfusion.domain.enums import InteractionState
+from xfusion.graph.auditing import log_graph_event
 from xfusion.graph.state import AgentGraphState
 from xfusion.policy.rules import evaluate_policy
 
@@ -28,14 +29,38 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
 
     if not decision.allowed:
         state.plan.interaction_state = InteractionState.REFUSED
+        state.plan.status = "refused"
         state.response = f"I cannot execute this step: {decision.reason}"
+        log_graph_event(
+            state,
+            step=step,
+            status="refused",
+            summary=state.response,
+            action_taken={
+                "tool": step.tool,
+                "parameters": step.parameters,
+                "policy_decision": decision.model_dump(),
+            },
+        )
     elif decision.requires_confirmation:
         state.plan.interaction_state = InteractionState.AWAITING_CONFIRMATION
+        state.plan.status = "awaiting_confirmation"
         # Requirements: Exact typed confirmation phrase is required.
         # Format: "I understand the risks of <intent>"
         phrase = f"I understand the risks of {step.intent}"
         step.confirmation_phrase = phrase
         state.pending_confirmation_phrase = phrase
         state.response = f"This action requires confirmation. Please type: '{phrase}'"
+        log_graph_event(
+            state,
+            step=step,
+            status="awaiting_confirmation",
+            summary=state.response,
+            action_taken={
+                "tool": step.tool,
+                "parameters": step.parameters,
+                "policy_decision": decision.model_dump(),
+            },
+        )
 
     return state

--- a/xfusion/graph/nodes/respond.py
+++ b/xfusion/graph/nodes/respond.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from xfusion.domain.enums import InteractionState
+from xfusion.graph.response import format_agent_response
 from xfusion.graph.state import AgentGraphState
 
 
@@ -9,12 +9,5 @@ def respond_node(state: AgentGraphState) -> AgentGraphState:
     if not state.plan:
         return state
 
-    if state.plan.interaction_state == InteractionState.COMPLETED:
-        state.response = f"Task completed successfully: {state.plan.goal}\n\n" + state.response
-    elif state.plan.interaction_state == InteractionState.REFUSED:
-        state.response = f"I cannot proceed: {state.response}"
-    elif state.plan.interaction_state == InteractionState.AWAITING_CONFIRMATION:
-        # Response is already set in policy_node
-        pass
-
+    state.response = format_agent_response(state)
     return state

--- a/xfusion/graph/nodes/update.py
+++ b/xfusion/graph/nodes/update.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 from datetime import datetime
 
+from xfusion.audit.jsonl_sink import JsonlAuditSink
+from xfusion.audit.logger import AuditLogger
 from xfusion.domain.enums import InteractionState, StepStatus
 from xfusion.graph.state import AgentGraphState
 
@@ -13,17 +15,50 @@ def update_node(state: AgentGraphState) -> AgentGraphState:
 
     # Create audit record
     if state.current_step_id:
+        step = next(
+            (
+                candidate
+                for candidate in state.plan.steps
+                if candidate.step_id == state.current_step_id
+            ),
+            None,
+        )
+        action_taken: dict[str, object] = {
+            "tool": step.tool if step else None,
+            "parameters": step.parameters if step else {},
+            "output": state.step_outputs.get(state.current_step_id, {}),
+        }
+        after_state: dict[str, object] = {
+            "plan_status": state.plan.status,
+            "step_status": step.status if step else "unknown",
+        }
         record = {
             "timestamp": datetime.now().isoformat(),
             "plan_id": state.plan.plan_id,
             "step_id": state.current_step_id,
             "interaction_state": state.plan.interaction_state,
+            "before_state": state.environment.model_dump(),
+            "action_taken": action_taken,
+            "after_state": after_state,
             "verification_result": state.verification_result.model_dump()
             if state.verification_result
             else {},
-            "status": state.plan.status,
+            "status": str(step.status if step else state.plan.status),
+            "summary": state.response,
         }
         state.audit_records.append(record)
+        if state.audit_log_path and step:
+            AuditLogger(JsonlAuditSink(state.audit_log_path)).log_step(
+                plan_id=state.plan.plan_id,
+                step_id=state.current_step_id,
+                interaction_state=str(state.plan.interaction_state),
+                before_state=record["before_state"],
+                action_taken=action_taken,
+                after_state=after_state,
+                verification_result=record["verification_result"],
+                status=str(step.status),
+                summary=state.response,
+            )
 
     # Check if plan is complete or blocked
     if state.plan.interaction_state == InteractionState.EXECUTING:

--- a/xfusion/graph/nodes/update.py
+++ b/xfusion/graph/nodes/update.py
@@ -1,10 +1,7 @@
 from __future__ import annotations
 
-from datetime import datetime
-
-from xfusion.audit.jsonl_sink import JsonlAuditSink
-from xfusion.audit.logger import AuditLogger
 from xfusion.domain.enums import InteractionState, StepStatus
+from xfusion.graph.auditing import log_graph_event
 from xfusion.graph.state import AgentGraphState
 
 
@@ -23,39 +20,10 @@ def update_node(state: AgentGraphState) -> AgentGraphState:
             ),
             None,
         )
-        action_taken: dict[str, object] = {
-            "tool": step.tool if step else None,
-            "parameters": step.parameters if step else {},
-            "output": state.step_outputs.get(state.current_step_id, {}),
-        }
-        after_state: dict[str, object] = {
-            "plan_status": state.plan.status,
-            "step_status": step.status if step else "unknown",
-        }
-        record = {
-            "timestamp": datetime.now().isoformat(),
-            "plan_id": state.plan.plan_id,
-            "step_id": state.current_step_id,
-            "interaction_state": state.plan.interaction_state,
-            "before_state": state.environment.model_dump(),
-            "action_taken": action_taken,
-            "after_state": after_state,
-            "verification_result": state.verification_result.model_dump()
-            if state.verification_result
-            else {},
-            "status": str(step.status if step else state.plan.status),
-            "summary": state.response,
-        }
-        state.audit_records.append(record)
-        if state.audit_log_path and step:
-            AuditLogger(JsonlAuditSink(state.audit_log_path)).log_step(
-                plan_id=state.plan.plan_id,
-                step_id=state.current_step_id,
-                interaction_state=str(state.plan.interaction_state),
-                before_state=record["before_state"],
-                action_taken=action_taken,
-                after_state=after_state,
-                verification_result=record["verification_result"],
+        if step:
+            log_graph_event(
+                state,
+                step=step,
                 status=str(step.status),
                 summary=state.response,
             )

--- a/xfusion/graph/response.py
+++ b/xfusion/graph/response.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+from xfusion.domain.enums import InteractionState
+from xfusion.graph.state import AgentGraphState
+
+
+def format_agent_response(state: AgentGraphState) -> str:
+    """Build the judge-facing response contract from deterministic state."""
+    if not state.plan:
+        return state.response
+
+    plan = state.plan
+    env = state.environment
+    plan_tools = ", ".join(step.tool for step in plan.steps) if plan.steps else "none"
+    risk = state.policy_decision.risk_level if state.policy_decision else "none"
+    risk_reason = (
+        state.policy_decision.reason if state.policy_decision else "No policy action needed."
+    )
+    verification = (
+        state.verification_result.summary
+        if state.verification_result
+        else "Not executed for this state."
+    )
+    action = state.response or "No action executed."
+
+    if plan.interaction_state == InteractionState.AWAITING_CONFIRMATION:
+        action = f"Confirmation required: type '{state.pending_confirmation_phrase}'."
+    elif plan.interaction_state == InteractionState.AWAITING_DISAMBIGUATION:
+        action = plan.clarification_question or state.response
+
+    next_step = _next_recommendation(state)
+
+    return "\n".join(
+        [
+            f"Intent: {plan.goal}",
+            (
+                "Environment: "
+                f"{env.distro_family} {env.distro_version}; "
+                f"user={env.current_user}; sudo={env.sudo_available}; "
+                f"systemd={env.systemd_available}; package={env.package_manager}; "
+                f"disk_pressure={env.disk_pressure}"
+            ),
+            f"Plan: {len(plan.steps)} step(s): {plan_tools}",
+            f"Risk: {risk} - {risk_reason}",
+            f"Action: {action}",
+            f"Verification: {verification}",
+            f"State: {plan.interaction_state}; status={plan.status}",
+            f"Next: {next_step}",
+        ]
+    )
+
+
+def _next_recommendation(state: AgentGraphState) -> str:
+    plan = state.plan
+    if not plan:
+        return "Ask for a Linux administration task."
+    if plan.interaction_state == InteractionState.AWAITING_CONFIRMATION:
+        return "Type the exact confirmation phrase to proceed, or anything else to abort."
+    if plan.interaction_state == InteractionState.AWAITING_DISAMBIGUATION:
+        return "Provide the missing target, scope, or risk boundary."
+    if plan.interaction_state == InteractionState.REFUSED:
+        return "Choose a narrower safe target or request a read-only inspection."
+    if plan.interaction_state == InteractionState.FAILED:
+        return "Review the verification failure before retrying."
+    if plan.interaction_state == InteractionState.COMPLETED:
+        return "Review the verification result and audit log before taking follow-up action."
+    return "Continue with the next safe planned step."

--- a/xfusion/graph/response.py
+++ b/xfusion/graph/response.py
@@ -63,5 +63,9 @@ def _next_recommendation(state: AgentGraphState) -> str:
     if plan.interaction_state == InteractionState.FAILED:
         return "Review the verification failure before retrying."
     if plan.interaction_state == InteractionState.COMPLETED:
+        if "disk" in plan.goal.lower() and (
+            "clean" in plan.goal.lower() or "full" in plan.goal.lower()
+        ):
+            return "Consider preventive monitoring for disk pressure and cleanup candidate growth."
         return "Review the verification result and audit log before taking follow-up action."
     return "Continue with the next safe planned step."

--- a/xfusion/graph/state.py
+++ b/xfusion/graph/state.py
@@ -25,3 +25,4 @@ class AgentGraphState(BaseModel):
     pending_confirmation_phrase: str | None = None
     response: str = ""
     audit_records: list[dict[str, object]] = Field(default_factory=list)
+    audit_log_path: str | None = None

--- a/xfusion/policy/rules.py
+++ b/xfusion/policy/rules.py
@@ -21,6 +21,7 @@ def evaluate_policy(
         or tool == "system.current_user"
         or tool == "system.service_status"
         or tool.startswith("disk.check")
+        or tool.startswith("disk.find")
         or tool.startswith("file.search")
         or tool.startswith("file.preview")
         or tool.startswith("process.list")
@@ -86,11 +87,18 @@ def evaluate_policy(
 
     # Cleanup is medium risk
     if tool == "cleanup.safe_disk_cleanup":
+        if parameters.get("execute") is not True:
+            return PolicyDecision(
+                risk_level=RiskLevel.LOW,
+                allowed=True,
+                requires_confirmation=False,
+                reason="Cleanup preview is read-only and bounded to approved candidates.",
+            )
         return PolicyDecision(
             risk_level=RiskLevel.MEDIUM,
             allowed=True,
             requires_confirmation=True,
-            reason="File cleanup can result in data loss and requires confirmation.",
+            reason="File cleanup deletes approved candidates and requires confirmation.",
         )
 
     # Default to forbidden for unknown mutating tools

--- a/xfusion/tools/cleanup.py
+++ b/xfusion/tools/cleanup.py
@@ -1,5 +1,9 @@
 from __future__ import annotations
 
+import shutil
+import time
+from pathlib import Path
+
 from xfusion.execution.command_runner import CommandRunner
 from xfusion.policy.protected_paths import is_protected
 from xfusion.tools.base import ToolOutput
@@ -11,23 +15,147 @@ class CleanupTools:
     def __init__(self, runner: CommandRunner) -> None:
         self.runner = runner
 
-    def safe_disk_cleanup(self, path: str = "/tmp", limit: int = 20) -> ToolOutput:
-        """Preview approved cleanup candidates without broad shell passthrough."""
-        if is_protected(path, ("/", "/etc", "/boot", "/usr", "/var/lib")):
-            return ToolOutput(
-                summary=f"Refusing cleanup of protected path {path}.",
-                data={"error": "protected_path"},
-            )
+    def safe_disk_cleanup(
+        self,
+        approved_paths: list[str] | None = None,
+        candidate_class: str = "demo_cache",
+        older_than_days: int = 0,
+        max_files: int = 20,
+        max_bytes: int = 50_000_000,
+        execute: bool = False,
+        path: str | None = None,
+        limit: int | None = None,
+    ) -> ToolOutput:
+        """Preview or delete explicitly approved cleanup candidates."""
+        if approved_paths is None:
+            approved_paths = [path or "/tmp"]
+        if limit is not None:
+            max_files = limit
 
-        safe_limit = max(1, min(limit, 50))
-        res = self.runner.run(["find", path, "-maxdepth", "1", "-type", "f", "-print"])
-        if res.exit_code != 0:
-            return ToolOutput(
-                summary=f"Cleanup preview failed: {res.stderr}", data={"error": res.stderr}
-            )
+        protected = ("/", "/etc", "/boot", "/usr", "/var/lib")
+        for approved_path in approved_paths:
+            if is_protected(approved_path, protected):
+                return ToolOutput(
+                    summary=f"Refusing cleanup of protected path {approved_path}.",
+                    data={"error": "protected_path", "path": approved_path},
+                )
 
-        candidates = res.stdout.splitlines()[:safe_limit]
-        return ToolOutput(
-            summary=f"Previewed {len(candidates)} safe cleanup candidates in {path}.",
-            data={"previewed_candidates": candidates, "deleted": [], "ok": True},
+        candidates = self._find_candidates(
+            approved_paths=approved_paths,
+            candidate_class=candidate_class,
+            older_than_days=older_than_days,
+            max_files=max_files,
+            max_bytes=max_bytes,
         )
+
+        if not execute:
+            return ToolOutput(
+                summary=f"Previewed {len(candidates)} safe cleanup candidates.",
+                data={
+                    "previewed_candidates": candidates,
+                    "deleted": [],
+                    "reclaimed_bytes": 0,
+                    "ok": True,
+                },
+            )
+
+        deleted: list[str] = []
+        reclaimed_bytes = 0
+        for candidate in candidates:
+            target = Path(str(candidate["path"]))
+            raw_size = candidate["size_bytes"]
+            size = raw_size if isinstance(raw_size, int) else int(str(raw_size))
+            try:
+                if target.is_dir() and not target.is_symlink():
+                    shutil.rmtree(target)
+                else:
+                    target.unlink()
+            except FileNotFoundError:
+                pass
+            deleted.append(str(target))
+            reclaimed_bytes += size
+
+        return ToolOutput(
+            summary=f"Deleted {len(deleted)} safe cleanup candidates.",
+            data={
+                "previewed_candidates": candidates,
+                "deleted": deleted,
+                "reclaimed_bytes": reclaimed_bytes,
+                "ok": True,
+            },
+        )
+
+    def _find_candidates(
+        self,
+        *,
+        approved_paths: list[str],
+        candidate_class: str,
+        older_than_days: int,
+        max_files: int,
+        max_bytes: int,
+    ) -> list[dict[str, object]]:
+        cutoff = time.time() - (older_than_days * 86_400)
+        candidates: list[dict[str, object]] = []
+        remaining_bytes = max_bytes
+
+        for approved_path in approved_paths:
+            root = Path(approved_path)
+            if not root.exists() or not root.is_dir():
+                continue
+            patterns = _patterns_for_class(candidate_class)
+            for pattern in patterns:
+                for target in root.glob(pattern):
+                    if len(candidates) >= max_files or remaining_bytes <= 0:
+                        return candidates
+                    if target.is_symlink() or not _is_safe_candidate(target, candidate_class):
+                        continue
+                    try:
+                        stat = target.stat()
+                    except OSError:
+                        continue
+                    if stat.st_mtime > cutoff:
+                        continue
+                    size = _size_bytes(target)
+                    if size > remaining_bytes:
+                        continue
+                    candidates.append(
+                        {
+                            "path": str(target),
+                            "size_bytes": size,
+                            "candidate_class": candidate_class,
+                        }
+                    )
+                    remaining_bytes -= size
+
+        return candidates
+
+
+def _patterns_for_class(candidate_class: str) -> list[str]:
+    if candidate_class == "demo_cache":
+        return ["xfusion-demo-*"]
+    if candidate_class == "temp":
+        return ["xfusion-demo-*", "*.tmp"]
+    if candidate_class == "rotated_logs":
+        return ["*.gz", "*.1", "*.old"]
+    if candidate_class == "apt_cache":
+        return ["*.deb"]
+    return ["xfusion-demo-*"]
+
+
+def _is_safe_candidate(target: Path, candidate_class: str) -> bool:
+    name = target.name
+    if candidate_class in {"demo_cache", "temp"}:
+        return name.startswith("xfusion-demo-") or name.endswith(".tmp")
+    if candidate_class == "rotated_logs":
+        return name.endswith((".gz", ".1", ".old"))
+    if candidate_class == "apt_cache":
+        return name.endswith(".deb")
+    return False
+
+
+def _size_bytes(target: Path) -> int:
+    if target.is_file():
+        return target.stat().st_size
+    if target.is_dir():
+        return sum(path.stat().st_size for path in target.rglob("*") if path.is_file())
+    return 0


### PR DESCRIPTION
## Summary
- Add judge-facing response contract and persistent JSONL audit logging.
- Complete the seven-scenario demo spine, including safe cleanup preview/delete and workflow verification.
- Reconcile roadmap/docs status and add opt-in live VM rehearsal coverage.

## Test Plan
- [x] uv run pytest -q
- [x] uv run ruff check .
- [x] uv run ruff format --check .
- [x] uv run ty check

## Notes
- Live VM rehearsal remains opt-in via XFUSION_RUN_LIVE_VM=1 and is skipped by default.