### PR TITLE
[codex] Finalize v0.2 review readiness

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,29 +1,42 @@
 # XFusion Agent/Engineer Guide
 
-This repo contains **XFusion v0.1**, a safety-aware Linux administration agent for the AI Hackathon 2026 preliminary problem. The goal is not to build a generic shell wrapper. The goal is a deterministic, policy-governed, plan-executing system agent that can manage a real Linux server through natural language while remaining auditable and controllable.
+This repo contains **XFusion v0.2**, a capability-governed Linux operations
+agent for the AI Hackathon 2026 preliminary problem. The goal is not to build a
+generic shell wrapper. The goal is a deterministic, policy-governed,
+plan-executing system agent that can manage a real Linux server through natural
+language while remaining auditable and controllable.
 
 ## Current Status
 
-v0.1 is a Python CLI-first implementation. The frozen product/technical spec is the source of truth:
+v0.2 is a Python CLI-first implementation. The only normative product and
+technical spec is:
 
-- [docs/specs/xfusion-v0.1.md](docs/specs/xfusion-v0.1.md)
+- [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md)
+
+Historical legacy materials live under [docs/archive/v0.1](docs/archive/v0.1)
+and are explicitly non-normative.
 
 The current implementation includes:
 
-- explicit `ExecutionPlan` and step model
-- dependency enforcement
-- interaction states
+- capability-governed `ExecutionPlan` and step contracts
+- dependency and reference enforcement
 - deterministic policy engine
-- context-aware risk classification
-- short-lived graph state for active plans
-- typed confirmation boundaries
-- scoped tool router
+- approval records bound to typed confirmations and action fingerprints
+- controlled adapter runtime
+- XFusion Capability Schema validation for capability input/output contracts
+- output normalization and redaction before general-purpose exposure
 - verification flow
+- final responses derived from authoritative audit state
 - append-only JSONL audit traces via `XFUSION_AUDIT_LOG_PATH`
 - CLI entrypoint
 - OpenAI-compatible LLM client scaffold
 
-The LLM boundary is intentionally narrow. The LLM may help with language understanding, ambiguity support, plan drafting, and response wording. Policy classification, dependency enforcement, confirmation rules, execution permission, and final tool authorization remain deterministic.
+The LLM boundary is intentionally narrow. The model may help with request
+understanding, ambiguity support, plan drafting, diagnosis suggestions,
+verification suggestions, and response wording. Policy classification,
+dependency enforcement, reference resolution, approval rules, schema validation,
+execution permission, redaction, audit state, and final capability
+authorization remain deterministic.
 
 ## Project Commands
 
@@ -53,35 +66,34 @@ uv run ty check
 Start here:
 
 - [README.md](README.md): short project overview and development commands.
-- [docs/specs/xfusion-v0.1.md](docs/specs/xfusion-v0.1.md): frozen v0.1 spec and acceptance criteria.
+- [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md): normative v0.2 spec.
+- [docs/architecture/capability-schema.md](docs/architecture/capability-schema.md): XFusion Capability Schema contract.
+- [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md): reviewer notes.
 - [problem_statement.pdf](problem_statement.pdf): original contest problem statement.
 
-Submission and demo docs:
+Supporting docs:
 
-- [docs/demo-script.md](docs/demo-script.md): seven-scenario acceptance demo.
-- [docs/sandbox-lima.md](docs/sandbox-lima.md): official Lima Ubuntu VM demo sandbox notes.
-- [docs/self-test.md](docs/self-test.md): local and VM self-test checklist.
 - [docs/verification-suite.md](docs/verification-suite.md): standardized YAML scenario suite.
 - [verification/README.md](verification/README.md): verification suite editing guide.
-
-Agent architecture docs:
-
-- [docs/architecture/pydantic-langgraph-blueprint.md](docs/architecture/pydantic-langgraph-blueprint.md): current Pydantic v2 + LangGraph architecture and next-step blueprint.
-- [docs/tools.md](docs/tools.md): v0.1 tool surface and guarantees.
-- [docs/prompts/core-agent-prompt.md](docs/prompts/core-agent-prompt.md): documented LLM boundary and core agent prompt.
+- [docs/archive/v0.1](docs/archive/v0.1): historical, non-normative legacy materials.
 
 Core code:
 
-- [xfusion/domain/models](xfusion/domain/models): Pydantic contracts for plans, environment, policy, verification, audit, and scenarios.
-- [xfusion/graph](xfusion/graph): LangGraph state, nodes, wiring, response formatting, and audit event helpers.
-- [xfusion/policy](xfusion/policy): deterministic policy, protected path checks, and confirmation helpers.
-- [xfusion/tools](xfusion/tools): scoped typed tools for system, disk, file, process, user, and cleanup operations.
+- [xfusion/domain/models](xfusion/domain/models): Pydantic contracts for plans, environment, policy, verification, audit, capabilities, and scenarios.
+- [xfusion/capabilities](xfusion/capabilities): capability registry and schema contract validation.
+- [xfusion/planning](xfusion/planning): static plan validation and reference resolution.
+- [xfusion/execution](xfusion/execution): controlled runtime and command runner.
+- [xfusion/graph](xfusion/graph): LangGraph state, nodes, wiring, response formatting, and audit helpers.
+- [xfusion/policy](xfusion/policy): deterministic policy, approval, protected path checks, and confirmation helpers.
+- [xfusion/tools](xfusion/tools): scoped typed adapters for system, disk, file, process, user, and cleanup operations.
 - [xfusion/audit](xfusion/audit): JSONL audit trace writer.
 - [xfusion/app/cli.py](xfusion/app/cli.py): CLI entrypoint.
 - [xfusion/llm/client.py](xfusion/llm/client.py): OpenAI-compatible client scaffold.
 
 Tests:
 
+- [tests/test_v02_contracts.py](tests/test_v02_contracts.py): v0.2 plan, approval, role, and runtime contracts.
+- [tests/test_v02_hardening.py](tests/test_v02_hardening.py): safety hardening, schema contract, redaction, audit, and documentation invariants.
 - [tests/test_smoke.py](tests/test_smoke.py): CLI and graph smoke tests.
 - [tests/test_plan_correctness.py](tests/test_plan_correctness.py): plan shape, dependency, refusal, and abort behavior.
 - [tests/test_data_flow.py](tests/test_data_flow.py): step-output data flow across workflows.
@@ -93,28 +105,31 @@ Tests:
 
 ## Architecture Invariants
 
-Preserve these unless the frozen spec is intentionally revised:
+Preserve these unless the v0.2 spec is intentionally revised:
 
 - No arbitrary shell passthrough.
 - Every request becomes an `ExecutionPlan`, even one-step requests.
+- Each step invokes exactly one registered capability.
 - A step cannot execute unless all dependencies succeeded.
-- Medium/high-risk actions require exact typed confirmation.
-- Confirmations never persist across plans.
+- References must use `$steps.<step_id>.outputs.<field>` and resolve only from authorized upstream outputs.
+- Capability input/output schemas are authoritative and fail closed when unsupported or malformed.
+- Mutating actions require policy approval before execution.
+- Approval is invalidated on material change.
 - Memory is short-lived and scoped to the active session/plan.
-- Tools accept structured input and return structured output.
-- Mutating tools require policy approval before execution.
+- Tools/adapters accept structured input and return structured output.
+- Output is normalized and redacted before model-visible, user-visible, or general-purpose audit/log exposure.
 - Verification is mandatory after execution.
-- Audit traces must map intent to plan, step, action, state changes, verification, and outcome.
+- Final responses derive from authoritative audit state.
 - The agent must ask clarification instead of guessing when target, scope, or risk boundary is unclear.
 
 ## Safety Model
 
-Risk levels:
+Risk tiers:
 
-- `low`: read-only inspection, usually executes directly.
-- `medium`: bounded state-changing actions, requires typed confirmation.
-- `high`: suspicious or broad actions, requires stricter handling or refusal.
-- `forbidden`: protected paths, unsafe privilege changes, or unsupported tools; always refused.
+- `tier_0`: read-only inspection within validated scope.
+- `tier_1`: bounded reversible mutation, requires human approval.
+- `tier_2`: high-risk mutation, requires admin approval or denial.
+- `tier_3`: prohibited or broad-impact operation, denied.
 
 Protected targets include:
 
@@ -127,7 +142,9 @@ Protected targets include:
 - broad recursive permission changes
 - unclear destructive operations
 
-Context matters. For example, bounded log cleanup can be more reasonable under high disk pressure than when disk pressure is normal. Keep risk reasoning grounded in `EnvironmentModel`.
+Context matters. For example, bounded log cleanup can be more reasonable under
+high disk pressure than when disk pressure is normal. Keep risk reasoning
+grounded in `EnvironmentModel`.
 
 ## Implementation Notes
 
@@ -139,20 +156,9 @@ Context matters. For example, bounded log cleanup can be more reasonable under h
 - Official demo sandbox: Lima Ubuntu 24.04 VM on Apple Silicon macOS.
 - Docker is acceptable for development smoke tests only, not for the official demo.
 
-The current parser is deterministic for v0.1 stability. If wiring in LLM-based parsing, keep the deterministic policy and tool authorization boundary intact.
-
-## Roadmap Status
-
-| Area | Status |
-| --- | --- |
-| Pydantic + LangGraph control loop | implemented |
-| Exact typed confirmation | implemented |
-| Mandatory verification | implemented |
-| Persistent JSONL audit logs | implemented |
-| Seven-scenario demo spine | implemented |
-| Safe cleanup | implemented with limitations: approved demo/temp candidates only |
-| Live VM rehearsal | implemented with limitations: opt-in smoke test, not default |
-| SSH/web/voice/persistent memory/multi-agent orchestration | future |
+The parser is deterministic for stability. If wiring in LLM-based parsing, keep
+the deterministic policy, schema, approval, redaction, and tool authorization
+boundaries intact.
 
 ## Development Workflow
 
@@ -164,7 +170,7 @@ When changing behavior:
 4. Run `uv run ruff check .`.
 5. Run `uv run ruff format --check .`.
 6. Run `uv run ty check`.
-7. Update docs if the user-facing behavior, tool surface, safety model, or demo flow changed.
+7. Update docs if the user-facing behavior, capability surface, safety model, schema contract, or demo flow changed.
 
 Avoid unrelated refactors. This project is intentionally small and audit-friendly.
 
@@ -174,14 +180,13 @@ The judge-facing story is:
 
 ```text
 Natural language request
-→ explicit execution plan
-→ environment-aware policy decision
-→ typed confirmation when needed
-→ bounded tool execution
-→ verification
-→ state update
-→ audit trace
-→ clear natural-language response
+-> explicit execution plan
+-> reference and schema validation
+-> environment-aware policy decision
+-> approval-bound typed confirmation when needed
+-> controlled adapter execution
+-> output normalization and redaction
+-> verification
+-> authoritative audit trace
+-> clear audit-derived response
 ```
-
-The strongest v0.1 demo is the disk-pressure workflow: detect disk pressure, propose safe cleanup, explain why the candidates are safe in this environment, request confirmation, execute bounded cleanup, verify the result, and suggest preventive monitoring.

--- a/README.md
+++ b/README.md
@@ -74,14 +74,10 @@ Important trust boundary:
 
 - [xfusion/](xfusion/) - Python package and agent implementation
 - [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md) - normative v0.2 spec
-- [docs/architecture/schema-subset.md](docs/architecture/schema-subset.md) - supported capability schema subset
-- [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) - reviewer notes and known limitations
-- [docs/specs/xfusion-v0.1.md](docs/specs/xfusion-v0.1.md) - historical v0.1 spec
-- [docs/architecture/pydantic-langgraph-blueprint.md](docs/architecture/pydantic-langgraph-blueprint.md) - target architecture blueprint
-- [docs/demo-script.md](docs/demo-script.md) - seven-scenario acceptance demo
-- [docs/sandbox-lima.md](docs/sandbox-lima.md) - Lima sandbox setup
-- [docs/tools.md](docs/tools.md) - tool surface and guarantees
+- [docs/architecture/capability-schema.md](docs/architecture/capability-schema.md) - XFusion Capability Schema contract
+- [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) - reviewer notes
 - [docs/verification-suite.md](docs/verification-suite.md) - verification suite design
+- [docs/archive/v0.1/](docs/archive/v0.1/) - historical, non-normative legacy materials
 - [verification/scenarios/](verification/scenarios/) - YAML scenario suite
 - [tests/](tests/) - smoke, safety, workflow, and verification runner tests
 - [AGENTS.md](AGENTS.md) - context guide for future agents and engineers
@@ -172,7 +168,8 @@ the dangerous decisions inspectable and controllable.
 ## Status
 
 v0.2 capability-governed execution is implemented and tested. The v0.2 spec is
-the normative source of truth; v0.1 materials remain for historical demo context.
+the normative source of truth. Legacy materials live only in the historical
+archive and are explicitly non-normative.
 
 | Area | Status |
 | --- | --- |

--- a/README.md
+++ b/README.md
@@ -1,13 +1,14 @@
 # XFusion Guardian
 
-XFusion Guardian is a v0.1 safety-aware Linux administration agent for the AI
+XFusion Guardian is a v0.2 capability-governed Linux administration agent for the AI
 Hackathon 2026 preliminary problem: an operating-system intelligent agent that
 can manage a real Linux server through natural language.
 
-The project is demo-first and safety-first. It uses an explicit execution plan,
-deterministic policy checks, typed confirmation gates, mandatory verification,
-short-lived memory, and JSONL audit records so Linux admin workflows are
-explainable, bounded, and testable.
+The project is demo-first and safety-first. It uses typed capability proposals,
+explicit execution plans, deterministic policy checks, approval gates,
+controlled adapters, mandatory verification, short-lived memory, redaction, and
+JSONL audit records so Linux admin workflows are explainable, bounded, and
+testable.
 
 ## What It Does
 
@@ -16,14 +17,14 @@ explainable, bounded, and testable.
   verification contracts.
 - Senses environment facts such as distro, current user, sudo availability,
   systemd availability, package manager, disk pressure, and protected paths.
-- Routes only through scoped typed tools, never arbitrary shell passthrough.
-- Requires exact typed confirmation for medium/high-risk actions.
+- Routes only through registered capabilities, never arbitrary shell passthrough.
+- Requires approval-bound exact typed confirmation for mutation capabilities.
 - Refuses forbidden operations on protected paths such as `/`, `/etc`, `/usr`,
   `/boot`, and `/var/lib`.
 - Verifies postconditions after execution instead of trusting tool success.
 - Ships with a YAML verification suite for demo rehearsal and regression tests.
 
-## Current v0.1 Scope
+## Current v0.2 Scope
 
 Supported workflow areas:
 
@@ -43,19 +44,22 @@ Official demo sandbox:
 
 ## Architecture
 
-The implemented v0.1 follows a LangGraph-orchestrated control loop with
+The implemented v0.2 follows a LangGraph-orchestrated control loop with
 Pydantic contracts:
 
 ```text
-Parse
-  -> Disambiguate
-  -> Plan
-  -> Policy
-  -> Confirm
-  -> Execute
-  -> Verify
-  -> Update
-  -> Respond
+agent proposal
+  -> plan schema validation
+  -> dependency/DAG validation
+  -> reference validation/resolution
+  -> capability schema validation
+  -> policy decision
+  -> approval gate
+  -> controlled adapter execution
+  -> output normalization
+  -> redaction
+  -> verification
+  -> explanation
 ```
 
 Important trust boundary:
@@ -63,12 +67,16 @@ Important trust boundary:
 - LLMs may support language understanding, ambiguity detection, plan drafting,
   and response wording.
 - Deterministic Python code owns policy classification, dependency enforcement,
-  confirmation validation, execution authorization, and verification.
+  reference resolution, capability schema validation, approval validation,
+  execution authorization, output redaction, audit state, and verification.
 
 ## Repository Map
 
 - [xfusion/](xfusion/) - Python package and agent implementation
-- [docs/specs/xfusion-v0.1.md](docs/specs/xfusion-v0.1.md) - frozen v0.1 spec
+- [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md) - normative v0.2 spec
+- [docs/architecture/schema-subset.md](docs/architecture/schema-subset.md) - supported capability schema subset
+- [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) - reviewer notes and known limitations
+- [docs/specs/xfusion-v0.1.md](docs/specs/xfusion-v0.1.md) - historical v0.1 spec
 - [docs/architecture/pydantic-langgraph-blueprint.md](docs/architecture/pydantic-langgraph-blueprint.md) - target architecture blueprint
 - [docs/demo-script.md](docs/demo-script.md) - seven-scenario acceptance demo
 - [docs/sandbox-lima.md](docs/sandbox-lima.md) - Lima sandbox setup
@@ -145,29 +153,31 @@ default.
 ## Safety Posture
 
 XFusion Guardian is intentionally not a command passthrough proxy. Before any
-tool can run, the agent performs:
+capability can run, the agent performs:
 
 1. ambiguity detection
 2. execution plan construction
-3. dependency enforcement
-4. environment-aware deterministic policy evaluation
-5. exact typed confirmation when required
-6. bounded tool execution
-7. mandatory verification
-8. state update and audit summarization
+3. dependency and reference validation
+4. capability schema validation
+5. environment-aware deterministic policy evaluation
+6. approval validation when required
+7. controlled adapter execution
+8. output normalization and redaction
+9. mandatory verification
+10. state update and audit-derived response generation
 
 This keeps the demo agent agentic enough for multi-step workflows while keeping
 the dangerous decisions inspectable and controllable.
 
 ## Status
 
-v0.1 judge-ready demo spine is implemented and tested. The Pydantic + LangGraph
-architecture blueprint documents the current baseline plus future refinements.
+v0.2 capability-governed execution is implemented and tested. The v0.2 spec is
+the normative source of truth; v0.1 materials remain for historical demo context.
 
 | Area | Status |
 | --- | --- |
 | Explicit plan-executing graph | implemented |
-| Deterministic policy and exact confirmation | implemented |
+| Deterministic policy and approval records | implemented |
 | Persistent JSONL audit logs | implemented |
 | Seven acceptance demo scenarios | implemented |
 | Safe cleanup | implemented with limitations: approved demo/temp candidates only |

--- a/docs/architecture/capability-schema.md
+++ b/docs/architecture/capability-schema.md
@@ -1,9 +1,9 @@
-# Capability Schema Subset
+# XFusion Capability Schema
 
-XFusion v0.2 uses code-defined JSON-Schema-like dictionaries for capability
-`input_schema` and `output_schema` validation. The normative product behavior is
-defined in [docs/specs/xfusion-v0.2.md](../specs/xfusion-v0.2.md); this note
-documents the currently implemented validator subset for maintainers.
+XFusion v0.2 uses code-defined XFusion Capability Schema dictionaries for
+capability `input_schema` and `output_schema` validation. The normative product
+behavior is defined in [docs/specs/xfusion-v0.2.md](../specs/xfusion-v0.2.md);
+this note defines the supported schema contract for maintainers.
 
 The canonical implementation is [xfusion/capabilities/schema.py](../../xfusion/capabilities/schema.py).
 Extend that module and its tests when adding schema support. Do not add schema
@@ -11,7 +11,7 @@ keywords only in capability definitions and assume they are enforced.
 
 ## Supported Keywords
 
-The central runtime validator currently recognizes these keywords:
+The central validator recognizes these keywords:
 
 | Keyword | Supported behavior |
 | --- | --- |
@@ -46,14 +46,18 @@ The central runtime validator currently recognizes these keywords:
 | `type` | Supports `object`, `array`, `string`, `integer`, `number`, `boolean`, `null`, and lists of those names. |
 | `uniqueItems` | `true` requires array items to be unique by Python equality. |
 
-This is intentionally a subset, not a full JSON Schema implementation.
+This is an explicit XFusion contract inspired by JSON Schema. It is not a
+general standards-compliant JSON Schema implementation, and maintainers should
+not rely on unlisted JSON Schema vocabulary.
 
-## Unsupported Keywords Fail Closed
+## Unsupported Or Malformed Schemas Fail Closed
 
-Any keyword outside the supported set makes validation fail with an
-`unsupported schema keyword` error. This applies recursively inside nested
-`properties`, `items`, `additionalProperties`, `contains`, `not`, `allOf`,
-`anyOf`, and `oneOf` schemas.
+Any keyword outside the supported set makes schema validation fail with an
+`unsupported schema keyword` error. Malformed supported keywords also fail the
+schema contract, for example non-object `properties`, non-list `required`,
+invalid `type` names, invalid regex `pattern` values, invalid combiners, and
+invalid numeric bounds. These checks run at capability registration/startup and
+runtime value validation uses the same authoritative contract.
 
 Common unsupported examples include:
 
@@ -82,16 +86,19 @@ closed turns that mismatch into an explicit validation failure instead.
 
 ## Input And Output Validation
 
-Capability outputs are validated centrally in
+Capability schemas are validated when a `CapabilityRegistry` is constructed.
+Invalid schemas prevent registration and startup. Capability outputs are
+validated centrally in
 [xfusion/execution/runtime.py](../../xfusion/execution/runtime.py) before
 redaction, audit exposure, final response generation, or downstream reference
 use. Output schema validation failures are normalized as structured adapter
 outcomes and do not become successful upstream outputs.
 
 Capability inputs are checked during static plan validation and after reference
-resolution. Input schemas should stay simple, closed objects where possible:
-declare every accepted argument under `properties`, list required arguments in
-`required`, and set `additionalProperties` to `false`.
+resolution using the same XFusion Capability Schema contract. Input schemas
+should stay simple, closed objects where possible: declare every accepted
+argument under `properties`, list required arguments in `required`, and set
+`additionalProperties` to `false`.
 
 ## Extending The Subset
 
@@ -103,5 +110,5 @@ To add support for a new keyword:
 3. Add or update capability registry tests if registered capabilities start
    depending on the new keyword.
 4. Update this document in the same change.
-5. Keep unsupported or partially understood features failing closed until they
-   have deterministic validation coverage.
+5. Keep unsupported or newly proposed features failing closed until they have
+   deterministic validation coverage.

--- a/docs/architecture/schema-subset.md
+++ b/docs/architecture/schema-subset.md
@@ -1,0 +1,107 @@
+# Capability Schema Subset
+
+XFusion v0.2 uses code-defined JSON-Schema-like dictionaries for capability
+`input_schema` and `output_schema` validation. The normative product behavior is
+defined in [docs/specs/xfusion-v0.2.md](../specs/xfusion-v0.2.md); this note
+documents the currently implemented validator subset for maintainers.
+
+The canonical implementation is [xfusion/capabilities/schema.py](../../xfusion/capabilities/schema.py).
+Extend that module and its tests when adding schema support. Do not add schema
+keywords only in capability definitions and assume they are enforced.
+
+## Supported Keywords
+
+The central runtime validator currently recognizes these keywords:
+
+| Keyword | Supported behavior |
+| --- | --- |
+| `$comment` | Allowed annotation; not used for validation. |
+| `additionalProperties` | `false` forbids unknown object fields; a schema object validates extra fields. |
+| `allOf` | Value must satisfy every listed schema. |
+| `anyOf` | Value must satisfy at least one listed schema. |
+| `const` | Value must equal the declared constant. |
+| `contains` | Array must contain matching item(s), with `minContains`/`maxContains` when present. |
+| `description` | Allowed annotation; not used for validation. |
+| `enum` | Value must be one of the listed values. |
+| `exclusiveMaximum` | Numeric value must be lower than this bound. |
+| `exclusiveMinimum` | Numeric value must be higher than this bound. |
+| `items` | A schema object validates every array item. Tuple validation is not implemented. |
+| `maxContains` | Upper bound for array items matching `contains`. |
+| `maxItems` | Maximum array length. |
+| `maxLength` | Maximum string length. |
+| `maxProperties` | Maximum object property count. |
+| `maximum` | Inclusive numeric upper bound. |
+| `minContains` | Lower bound for array items matching `contains`; defaults to `1` when `contains` is present. |
+| `minItems` | Minimum array length. |
+| `minLength` | Minimum string length. |
+| `minProperties` | Minimum object property count. |
+| `minimum` | Inclusive numeric lower bound. |
+| `multipleOf` | Numeric value must be an integral multiple of a positive divisor. |
+| `not` | Value must not satisfy the nested schema. |
+| `oneOf` | Value must satisfy exactly one listed schema. |
+| `pattern` | String must match the Python regular expression. Invalid regex patterns fail validation. |
+| `properties` | Object fields are validated against nested schemas. |
+| `required` | Object must include the listed fields. |
+| `title` | Allowed annotation; not used for validation. |
+| `type` | Supports `object`, `array`, `string`, `integer`, `number`, `boolean`, `null`, and lists of those names. |
+| `uniqueItems` | `true` requires array items to be unique by Python equality. |
+
+This is intentionally a subset, not a full JSON Schema implementation.
+
+## Unsupported Keywords Fail Closed
+
+Any keyword outside the supported set makes validation fail with an
+`unsupported schema keyword` error. This applies recursively inside nested
+`properties`, `items`, `additionalProperties`, `contains`, `not`, `allOf`,
+`anyOf`, and `oneOf` schemas.
+
+Common unsupported examples include:
+
+- `$defs`
+- `$id`
+- `$ref`
+- `$schema`
+- `dependentRequired`
+- `dependentSchemas`
+- `else`
+- `format`
+- `if`
+- `patternProperties`
+- `prefixItems`
+- `propertyNames`
+- `then`
+- `unevaluatedItems`
+- `unevaluatedProperties`
+
+The fail closed behavior is a safety boundary. Capability schemas are part of
+the deterministic authority path: they gate adapter input and decide whether
+adapter output can become authoritative state or referenceable evidence. If a
+schema contains a keyword the validator does not implement, silently accepting
+the schema would create a false assurance that a constraint was enforced. Failing
+closed turns that mismatch into an explicit validation failure instead.
+
+## Input And Output Validation
+
+Capability outputs are validated centrally in
+[xfusion/execution/runtime.py](../../xfusion/execution/runtime.py) before
+redaction, audit exposure, final response generation, or downstream reference
+use. Output schema validation failures are normalized as structured adapter
+outcomes and do not become successful upstream outputs.
+
+Capability inputs are checked during static plan validation and after reference
+resolution. Input schemas should stay simple, closed objects where possible:
+declare every accepted argument under `properties`, list required arguments in
+`required`, and set `additionalProperties` to `false`.
+
+## Extending The Subset
+
+To add support for a new keyword:
+
+1. Update `SUPPORTED_SCHEMA_KEYWORDS` and validation logic in
+   [xfusion/capabilities/schema.py](../../xfusion/capabilities/schema.py).
+2. Add tests that demonstrate both accepted and rejected values.
+3. Add or update capability registry tests if registered capabilities start
+   depending on the new keyword.
+4. Update this document in the same change.
+5. Keep unsupported or partially understood features failing closed until they
+   have deterministic validation coverage.

--- a/docs/archive/v0.1/README.md
+++ b/docs/archive/v0.1/README.md
@@ -1,0 +1,15 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
+# Historical v0.1 Archive
+
+This directory preserves legacy planning, demo, sandbox, prompt, and tool notes
+from the earlier implementation. These files are retained for historical context
+only and must not be used as the current behavior contract.
+
+Current maintainers should start with:
+
+- [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md)
+- [README.md](../../../README.md)
+- [docs/architecture/capability-schema.md](../../architecture/capability-schema.md)

--- a/docs/archive/v0.1/core-agent-prompt.md
+++ b/docs/archive/v0.1/core-agent-prompt.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # XFusion v0.1 Core Agent Prompt
 
 This prompt documents the intended LLM boundary for v0.1. The current implementation keeps final policy and execution authorization deterministic.
@@ -26,4 +30,3 @@ Deterministic system components make the final decisions for:
 - tool authorization
 - verification status
 ```
-

--- a/docs/archive/v0.1/demo-script.md
+++ b/docs/archive/v0.1/demo-script.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # XFusion v0.1 Acceptance Demo Script
 
 Record the demo inside the Lima Ubuntu VM.
@@ -125,4 +129,3 @@ Expected:
 - Agent asks typed confirmation.
 - Agent verifies reclaimed/unchanged space.
 - Agent suggests preventive monitoring.
-

--- a/docs/archive/v0.1/pydantic-langgraph-blueprint.md
+++ b/docs/archive/v0.1/pydantic-langgraph-blueprint.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # Pydantic v2 + LangGraph Architecture Blueprint
 
 This document defines the current and target architecture for XFusion's **Pydantic v2 + LangGraph-first architecture**, with LangChain used only as optional integration glue.

--- a/docs/archive/v0.1/sandbox-lima.md
+++ b/docs/archive/v0.1/sandbox-lima.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # Lima Ubuntu Demo Sandbox
 
 The official v0.1 demo sandbox is a local Lima Ubuntu 24.04 VM on Apple Silicon macOS.

--- a/docs/archive/v0.1/self-test.md
+++ b/docs/archive/v0.1/self-test.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # XFusion v0.1 Self-Test Checklist
 
 ## Local Development

--- a/docs/archive/v0.1/spec.md
+++ b/docs/archive/v0.1/spec.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # XFusion v0.1 Spec: Safety-Aware Linux Admin Agent
 
 ## Summary

--- a/docs/archive/v0.1/tools.md
+++ b/docs/archive/v0.1/tools.md
@@ -1,3 +1,7 @@
+> [!IMPORTANT]
+> Historical, non-normative v0.1 material. For current behavior, use
+> [docs/specs/xfusion-v0.2.md](../../specs/xfusion-v0.2.md).
+
 # XFusion v0.1 Tool Definitions
 
 Tools accept structured input and return structured output. They are scoped, non-interactive, and do not expose arbitrary shell passthrough.
@@ -37,4 +41,3 @@ Tools accept structured input and return structured output. They are scoped, non
 ## Planning
 
 - `plan.explain_action`: explains supported actions and safe next steps.
-

--- a/docs/release-readiness-v0.2.md
+++ b/docs/release-readiness-v0.2.md
@@ -34,15 +34,15 @@ For the main execution path, read these files in order:
 10. [tests/test_v02_contracts.py](../tests/test_v02_contracts.py) and
     [tests/test_v02_hardening.py](../tests/test_v02_hardening.py)
 
-## Known Limitations
+## Intentional Boundaries
 
-- Full JSON Schema vocabulary is not implemented. The supported subset and
-  fail-closed boundary are documented in
-  [docs/architecture/schema-subset.md](architecture/schema-subset.md).
-- Unsupported schema keywords fail validation by design rather than being
-  ignored.
-- The v0.1 docs and demo materials remain in the repo for historical/demo
-  continuity. The v0.2 spec is the normative source for current behavior.
+- XFusion uses the explicit XFusion Capability Schema contract documented in
+  [docs/architecture/capability-schema.md](architecture/capability-schema.md), not a
+  general JSON Schema compatibility promise.
+- Unsupported schema keywords fail validation by design at capability
+  registration/startup and at runtime rather than being ignored.
+- Legacy materials are archived under [docs/archive/v0.1](archive/v0.1) with
+  non-normative banners. The v0.2 spec is the current source of truth.
 - SSH, web UI, voice, persistent memory, unrestricted shell execution, and
   multi-agent orchestration remain non-goals for this release.
 

--- a/docs/release-readiness-v0.2.md
+++ b/docs/release-readiness-v0.2.md
@@ -1,0 +1,58 @@
+# XFusion v0.2 Reviewer Notes
+
+This note summarizes the merge/release posture for the v0.2 implementation. The
+normative behavior remains [docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md).
+
+## What Changed
+
+- Execution is capability governed: plans invoke registered `capability + args`
+  contracts instead of the legacy `tool + parameters` surface.
+- Static validation rejects unknown capabilities, conflicting legacy fields,
+  invalid dependencies, fabricated references, unknown args, and schema
+  mismatches before policy or execution.
+- Policy, approval, runtime constraints, output normalization, redaction,
+  verification, and audit records form the deterministic authority path.
+- Adapter outputs are centrally schema-validated before they can be audited as
+  successful outcomes, referenced by downstream steps, or used in final
+  explanations.
+- Final responses are derived from authoritative audit state, including the
+  final explanation snapshot.
+
+## Reviewer Path
+
+For the main execution path, read these files in order:
+
+1. [docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md)
+2. [xfusion/domain/models/execution_plan.py](../xfusion/domain/models/execution_plan.py)
+3. [xfusion/capabilities/registry.py](../xfusion/capabilities/registry.py)
+4. [xfusion/planning/validator.py](../xfusion/planning/validator.py)
+5. [xfusion/planning/reference_resolver.py](../xfusion/planning/reference_resolver.py)
+6. [xfusion/policy/rules.py](../xfusion/policy/rules.py)
+7. [xfusion/execution/runtime.py](../xfusion/execution/runtime.py)
+8. [xfusion/graph/auditing.py](../xfusion/graph/auditing.py)
+9. [xfusion/graph/response.py](../xfusion/graph/response.py)
+10. [tests/test_v02_contracts.py](../tests/test_v02_contracts.py) and
+    [tests/test_v02_hardening.py](../tests/test_v02_hardening.py)
+
+## Known Limitations
+
+- Full JSON Schema vocabulary is not implemented. The supported subset and
+  fail-closed boundary are documented in
+  [docs/architecture/schema-subset.md](architecture/schema-subset.md).
+- Unsupported schema keywords fail validation by design rather than being
+  ignored.
+- The v0.1 docs and demo materials remain in the repo for historical/demo
+  continuity. The v0.2 spec is the normative source for current behavior.
+- SSH, web UI, voice, persistent memory, unrestricted shell execution, and
+  multi-agent orchestration remain non-goals for this release.
+
+## Verification Gate
+
+Before merge/release, run:
+
+```bash
+uv run pytest -q
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check
+```

--- a/docs/specs/xfusion-v0.2.md
+++ b/docs/specs/xfusion-v0.2.md
@@ -1,0 +1,759 @@
+# XFusion v0.2 Spec: Capability-Governed Linux Operations Agent
+
+## Summary
+
+XFusion v0.2 is a capability-based, policy-governed Linux operations agent. It
+lets model-assisted reasoning help with request understanding, observation,
+diagnosis, workflow planning, verification, repair suggestions, and explanation,
+while keeping all authority in deterministic infrastructure.
+
+v0.2 replaces the v0.1 `tool + parameters` execution surface with typed
+capability proposals, schema validation, explicit output references, policy
+decisions, approval records, controlled adapters, deterministic redaction,
+verification strategies, and full-pipeline audit instrumentation.
+
+The model may propose. The system authorizes and executes.
+
+## Normative Terms
+
+These terms are used consistently throughout the v0.2 specification:
+
+- **Authorized upstream output:** an output from a prior step that completed
+  successfully, was policy-allowed, was approved when approval was required, and
+  still belongs to the currently valid plan context.
+- **Material change:** any change that can alter what is touched, what authority
+  is needed, what risk tier applies, what evidence is consumed, or what outcome
+  an operator approved. This includes changes to normalized arguments,
+  referenced outputs, argument provenance, target context, scope, environment
+  profile, capability version, adapter id, approval mode, risk tier, or grouped
+  mutation membership.
+- **Equivalence:** a deterministic policy declaration that two invocations
+  differ only in ways that do not change target, scope, risk, authority,
+  referenced evidence, or operator-visible impact. Agents must not infer
+  equivalence from natural-language similarity.
+- **General-purpose audit/log exposure:** any audit, log, trace, message,
+  response, or stored record that may be visible to models, users, routine
+  operators, developer tooling, or non-privileged support workflows. This does
+  not include a future restricted privileged execution trace, which is outside
+  the minimum v0.2 logging surface.
+
+## Core Architecture
+
+### Reasoning Roles
+
+v0.2 defines a multi-role reasoning layer:
+
+- Supervisor
+- Observation
+- Diagnosis
+- Planning
+- Verification
+- Explanation
+
+These are separate reasoning roles with distinct contracts, budgets, and allowed
+proposal types. Their boundaries are normative and must be explicit enough to
+permit future runtime separation, although an initial implementation may execute
+multiple roles within one process, graph, or runtime agent.
+
+No reasoning role is authoritative. Reasoning roles must not execute, approve
+mutations, bypass policy, fabricate prior step outputs, consume unredacted secret
+material, or alter authoritative execution records.
+
+### Authoritative Pipeline
+
+The deterministic pipeline is mandatory:
+
+```text
+agent proposal
+  -> plan schema validation
+  -> dependency/DAG validation
+  -> reference validation/resolution
+  -> capability schema validation
+  -> policy decision
+  -> approval gate
+  -> controlled adapter execution
+  -> output normalization
+  -> redaction
+  -> verification
+  -> explanation
+```
+
+Capability schema validation may occur both before and after reference
+resolution. Pre-resolution validation checks shape, capability existence, legal
+argument sources, declared references, and static constraints. Post-resolution
+validation checks resolved values against the capability input schema.
+
+Audit instrumentation is required throughout the pipeline. User-visible
+explanations must be derived from authoritative audited state and must not depend
+on non-recorded agent memory or hidden reasoning.
+
+### Trust Boundary
+
+Untrusted or partially trusted inputs:
+
+- user natural-language requests
+- model-generated interpretations
+- model-generated workflow drafts
+- model-generated justifications
+- raw command-like text in any agent output
+
+Trusted deterministic components:
+
+- capability registry
+- schemas
+- static validator
+- dependency graph checker
+- reference resolver
+- policy engine
+- approval gate
+- execution adapters
+- runtime containment controls
+- output normalizer
+- redaction pipeline
+- audit logger
+
+No untrusted component may directly cause state-changing execution.
+
+## Reasoning Role Contracts
+
+### Supervisor
+
+The Supervisor interprets user intent, identifies whether the request needs
+observation, diagnosis, remediation, explanation, or clarification, and
+coordinates the other roles. It may assemble a draft workflow from role outputs.
+It must not execute, authorize, or approve.
+
+### Observation
+
+The Observation role proposes read-only capabilities for logs, service status,
+process state, disk state, file metadata, and similar evidence gathering. It may
+only propose Tier 0 capabilities and must not request unrestricted paths,
+unbounded outputs, or mutation.
+
+### Diagnosis
+
+The Diagnosis role consumes typed observations and produces advisory hypotheses.
+It may rank hypotheses, cite observations, identify missing evidence, and
+estimate confidence. It must not change authorization, policy outcome, or risk
+classification.
+
+### Planning
+
+The Planning role converts a goal and evidence into a typed workflow DAG. It
+must propose only registered capabilities, define dependencies, reference prior
+outputs explicitly, attach verification strategy, and avoid unresolved or
+fabricated references.
+
+### Verification
+
+The Verification role evaluates execution results against the plan's verification
+strategy. Model-assisted verification may operate only on redacted inputs.
+Trusted deterministic verifiers may inspect richer structured outputs when
+secret-handling policy permits. Verification must not automatically re-run
+mutations unless a new or equivalent authorization path permits it.
+
+### Explanation
+
+The Explanation role summarizes intent, evidence, policy decisions, approval
+requirements, denials, execution results, verification results, and safe next
+steps. It must derive user-visible explanations from authoritative audited state
+and must not obscure blocked or denied actions.
+
+## Capability Model
+
+### Capability Definition
+
+Every executable operation must map to a registered capability. Unknown
+capabilities are denied by default.
+
+Each capability definition must include:
+
+- `name`
+- `version`
+- `verb`
+- `object`
+- `risk_tier`
+- `approval_mode`
+- `allowed_environments`
+- `allowed_actor_types`
+- `scope_model`
+- `input_schema`
+- `output_schema`
+- `runtime_constraints`
+- `adapter_id`
+- `is_read_only`
+- `preview_builder`
+- `verification_recommendation`
+- `redaction_policy`
+
+Capability definitions are the executable surface. Free-form command strings are
+not a capability surface.
+
+Capability definitions are code-defined. Environment policy may constrain where
+and how a capability may run, but it must not redefine canonical capability
+schemas or adapter contracts.
+
+### Capability Examples
+
+Tier 0 read-only examples:
+
+- `get_service_status`
+- `get_service_logs`
+- `find_process_on_port`
+- `verify_port_free`
+- `read_file`
+- `list_directory`
+- `search_logs`
+- `get_disk_usage`
+- `get_memory_usage`
+- `read_config_snippet`
+
+Tier 1 bounded mutation examples:
+
+- `terminate_process`
+- `restart_service`
+- `rotate_logs`
+- `clear_temp_cache`
+- `run_approved_script`
+
+Tier 2 high-risk mutation examples:
+
+- `delete_files`
+- `modify_config_file`
+- `run_db_migration`
+- `rollout_restart`
+- `package_install`
+
+Tier 3 prohibited or broad-impact examples:
+
+- unrestricted shell
+- unrestricted sudo
+- arbitrary SSH or SCP
+- arbitrary `docker`, `kubectl`, `git`, `python`, `bash`, or `sh`
+- unrestricted package installation
+- unrestricted network fetch-and-run
+
+## Plan Model
+
+### Plan Contract
+
+Every request that reaches planning becomes a typed workflow plan, even when the
+workflow has one step.
+
+Required plan fields:
+
+- `plan_id`
+- `goal`
+- `intent_class`
+- `target_context`
+- `created_by`
+- `created_at`
+- `steps`
+- `assumptions`
+- `safety_notes`
+- `approval_summary`
+- `verification_strategy`
+
+### Step Contract
+
+Each step invokes exactly one registered capability.
+
+Required step fields:
+
+- `id`
+- `capability`
+- `depends_on`
+- `args`
+- `expected_outputs`
+- `justification`
+- `risk_hint`
+- `approval_required_hint`
+- `preview_summary`
+- `on_failure`
+- `verification_step_ids`
+- `state`
+
+The authoritative execution surface is `capability + args`, not
+`tool + parameters`.
+
+### Allowed Argument Sources
+
+A step argument may come from:
+
+- a literal
+- validated user-provided input
+- a prior successful step output reference
+- policy-injected trusted context
+
+A step argument must not come from:
+
+- unresolved model text
+- free-form shell fragments
+- outputs from failed steps
+- outputs from skipped steps
+- implicit default fabrication
+
+### Reference Syntax
+
+References use this syntax:
+
+```text
+$steps.<step_id>.outputs.<field>
+```
+
+Example:
+
+```json
+{
+  "pid": "$steps.locate.outputs.pid",
+  "signal": "TERM"
+}
+```
+
+The validator and resolver must reject:
+
+- unknown step ids
+- references to steps that are not declared dependencies when dependency
+  compatibility is required
+- missing output fields
+- type mismatches
+- references to non-success states
+- references across disallowed trust boundaries
+- references whose provenance is not acceptable for the target capability
+
+## Static Validation
+
+Before policy evaluation or execution, every plan must undergo static
+validation.
+
+The validator must check:
+
+- plan schema validity
+- unique step ids
+- every capability exists in the registry
+- dependency graph is acyclic
+- dependency references point to known steps
+- reference syntax is valid
+- referenced outputs are declared by upstream output contracts
+- step arguments match capability input schemas after resolution
+- forbidden fields are absent
+- mutation is not hidden behind misleading metadata
+- every mutating workflow defines a verification strategy
+
+If validation fails, the plan must not proceed to policy evaluation or execution.
+The system must produce structured validation errors and preserve the invalid
+draft and validation failure in audit records.
+
+## Policy Model
+
+### Policy Authority
+
+The policy engine is the sole authority that converts a normalized capability
+invocation into:
+
+- `allow`
+- `require_approval`
+- `deny`
+
+Policy inputs include:
+
+- capability metadata
+- resolved arguments
+- argument provenance
+- environment profile
+- actor type
+- host class
+- target scope
+- request intent
+- prior approval state
+- time and quota context where applicable
+
+If no rule matches exactly, the decision is `deny`.
+
+### Policy Decision Contract
+
+Every policy decision must produce an authoritative record:
+
+- `decision`
+- `matched_rule_id`
+- `risk_tier`
+- `approval_mode`
+- `constraints_applied`
+- `reason_codes`
+- `explainability_record`
+
+The explainability record must answer which capability matched, which rule
+matched, which constraints applied, why approval was or was not required, and why
+the action was denied if denied.
+
+### Risk Tiers
+
+Risk tiers are normative:
+
+- Tier 0: read-only inspection within validated scope.
+- Tier 1: bounded reversible mutation.
+- Tier 2: high-risk mutation.
+- Tier 3: prohibited or broad-impact operation.
+
+Risk tier may be declared by capability metadata and tightened by environment
+policy.
+
+Production defaults are strict:
+
+- Tier 0 auto allowed only within explicit scope.
+- Tier 1 requires human approval.
+- Tier 2 requires admin approval or denial.
+- Tier 3 is denied.
+
+## Approval Model
+
+### Approval Modes
+
+Supported approval modes:
+
+- `auto`
+- `human`
+- `admin`
+- `deny`
+
+### Material Change And Equivalence
+
+Material change and equivalence use the definitions in [Normative Terms](#normative-terms).
+Approval code, policy code, and repair code must apply the same definitions.
+
+### Approval Records
+
+Approval-gated steps must produce a preview payload and bind the operator's exact
+typed confirmation to:
+
+- approval record id
+- normalized capability set
+- target context
+- action fingerprint or hash
+- expiry
+
+Prior approval state may satisfy an approval requirement only when the approved
+action fingerprint, target context, referenced outputs, approval mode, and TTL
+still match.
+
+### Preview Payload
+
+Every approval-gated step must produce a preview object with:
+
+- impacted target
+- action summary
+- reversibility estimate
+- expected blast radius
+- exact capability and normalized args
+- argument provenance summary
+- rollback notes if available
+- approval mode
+- expiry
+
+### Approval Invalidation
+
+Approval must be invalidated when:
+
+- arguments change materially
+- referenced upstream outputs change materially
+- target host, service, process, file, or scope changes
+- the plan is repaired or rewritten in a way that changes impact
+- scope expands
+- risk tier increases
+- approval TTL expires
+
+Multi-step approval is allowed only when every grouped mutation and target is
+listed explicitly in the preview. Hidden follow-up mutations are not covered.
+
+## Execution Runtime
+
+### Runtime Invariants
+
+All adapters must execute through controlled subprocess/runtime execution with:
+
+- `shell=False`
+- no model-originated command text
+- no command interpolation
+- no interactive TTY
+- strict timeout limits
+- stdout and stderr byte limits
+- bounded environment variables
+- bounded working directory
+- outbound network denied by default unless the capability explicitly requires
+  it and policy allows it
+- least privilege
+- capability-specific privilege rules
+- output normalization before model or user exposure
+
+The default execution identity is non-root. If elevated privileges are required,
+they must be narrowly scoped to the capability and mediated through
+capability-specific privilege rules. Unrestricted sudo is prohibited.
+
+### Adapter Contract
+
+Each adapter must:
+
+- accept already validated typed input
+- reject invalid inputs defensively
+- avoid parsing model output
+- avoid accepting free-form shell text
+- construct process argument arrays safely
+- enforce runtime constraints
+- normalize raw operating-system results into the capability output schema
+- emit structured failure information
+- pass output through redaction before model-visible, user-visible, or
+  general-purpose audit/log exposure
+
+An adapter such as `run_command(command: str)` is prohibited. An adapter such as
+`get_service_logs(service: str, lines: int)` is acceptable when backed by a
+registered capability, validated scope, and controlled execution.
+
+## Secret Handling And Redaction
+
+Secrets are denied by default.
+
+The system must deny known secret paths, including at least:
+
+- SSH private keys
+- kubeconfigs
+- `.env` files containing credentials
+- database credential files
+- cloud credential files
+- `/etc/shadow`
+- root-only secret material
+- secret mounts
+
+The system must apply deterministic pattern redaction for common token, key,
+credential, and secret shapes in adapter output before any model-visible,
+user-visible, or general-purpose audit/log exposure.
+
+Redaction policy is deterministic. Agents must not decide whether text "looks
+secret enough."
+
+Restricted privileged execution traces may exist in future implementations, but
+they are outside the minimum v0.2 general-purpose logging surface.
+
+## Observations And Diagnosis
+
+### Observation Contract
+
+Observations are typed records derived from read-only capability outputs.
+
+Examples:
+
+- service status
+- port usage
+- log summaries
+- disk usage
+- memory usage
+- config snippets
+- file metadata
+
+Each observation must include:
+
+- `observation_id`
+- `type`
+- `source_step_id`
+- `source_capability`
+- `timestamp`
+- `normalized_payload`
+- `provenance`
+- `redaction_status`
+- `confidence` or `fidelity`
+
+### Diagnosis Contract
+
+Diagnosis is advisory only. It may contain:
+
+- `hypothesis_id`
+- summary
+- supporting observation ids
+- counterevidence
+- confidence
+- missing evidence
+- recommended observation steps
+
+Diagnosis must not imply permission to mutate and must not replace policy.
+
+## Verification And Repair
+
+Every mutating workflow must define a verification strategy and must include at
+least one explicit verification step unless the plan records that no meaningful
+verifier exists. If no meaningful verifier exists, the workflow must state that
+explicitly and classify the final outcome as unverified rather than silently
+assuming success.
+
+Verification outcomes:
+
+- `success`
+- `partial_success`
+- `failed`
+- `inconclusive`
+
+Model-assisted verification may operate only on redacted inputs. Trusted
+deterministic verifiers may inspect richer structured outputs when policy
+permits.
+
+If verification fails, v0.2 may propose a repair plan. Any materially changed
+repair plan must re-enter static validation, reference checks, capability schema
+validation, policy evaluation, and approval. Repairs that expand scope, increase
+risk, change targets, or change referenced outputs must invalidate prior
+approval unless policy explicitly allows equivalence as defined by the approval
+model.
+
+Example: if `terminate_process(signal=TERM)` fails and a repair suggests
+`signal=KILL`, the repair is a new higher-risk action. Policy must be
+re-evaluated, and prior approval must not be assumed to cover the escalation.
+
+## Failure Handling
+
+The system must distinguish these failure classes:
+
+- validation failure
+- policy denial
+- approval pending
+- approval denied
+- approval expired
+- adapter failure
+- execution failure
+- runtime timeout
+- scope violation
+- redaction failure
+- verification failure
+- internal system failure
+
+User-visible responses must distinguish these plainly. "Needs approval",
+"policy denied", "plan invalid", "execution failed", and "verification failed"
+are different states and must not be collapsed into a generic failure.
+
+If the system cannot confidently validate scope, arguments, target identity, or
+secret-handling state, it must fail closed.
+
+## Audit And Observability
+
+Audit is pipeline-wide instrumentation, not an end-stage log.
+
+For every request, the system must record:
+
+- original user request
+- interpreted intent
+- role proposals
+- plan drafts
+- validation results and failures
+- dependency checks
+- reference validation and resolution
+- normalized capability invocations
+- policy decisions
+- approval requests and responses
+- controlled execution invocations
+- adapter outcomes
+- output normalization metadata
+- redaction metadata
+- verification outcomes
+- final explanation snapshot
+
+The final explanation snapshot is the exact authoritative record from which the
+user-visible response was derived.
+
+Each step log must include:
+
+- step id
+- capability
+- normalized args
+- argument provenance
+- resolved references
+- matched policy rule
+- approval mode
+- approval id if applicable
+- action fingerprint if applicable
+- adapter id
+- start and end timestamps
+- execution status
+- normalized output
+- redaction metadata
+- verification status
+
+An operator or reviewer must be able to reconstruct what the system thought the
+user wanted, what it planned, why each step was allowed or blocked, what exactly
+ran, what changed, what was verified, and what was explained to the user.
+
+## Acceptance Criteria
+
+A v0.2 implementation is acceptable only if it passes both scenario-based and
+invariant-based acceptance tests.
+
+### Required Scenarios
+
+- Read-only service diagnosis.
+- Safe "free port" remediation.
+- Disk cleanup preview, approval, and verification.
+- Blocked protected-path action.
+- Blocked secret read.
+- Invalid or fabricated reference rejection.
+- Repair proposal after failed verification.
+- Stale approval invalidation after target or upstream output change.
+- Deny-by-default rejection of an unknown capability.
+
+### Required Invariants
+
+- Registered capability required for execution.
+- Schema validation for every capability invocation.
+- Unknown or extra step fields rejected unless explicitly allowed by schema.
+- DAG and reference validation before execution.
+- References resolve only from authorized upstream outputs.
+- Policy deny-by-default when no exact rule matches.
+- Approval invalidation on material change.
+- Adapter runtime constraints enforced.
+- Redaction before any model-visible, user-visible, or general-purpose logging
+  surface.
+- Verification strategy present for every mutating workflow.
+- User-visible explanation reproducible from authoritative audit records.
+
+## Migration From v0.1
+
+This section is explanatory and comparative. The normative source of truth for
+v0.2 behavior remains the architecture, capability, policy, approval, runtime,
+redaction, verification, repair, and audit sections above.
+
+Concept mapping:
+
+- v0.1 tools become v0.2 capabilities.
+- v0.1 `parameters` become schema-validated capability `args`.
+- v0.1 ad hoc output references become typed `$steps...` references.
+- v0.1 direct registry dispatch becomes controlled adapter execution.
+- v0.1 confirmation phrases become approval records bound to action
+  fingerprints.
+- v0.1 step audit expands into full-pipeline audit instrumentation.
+- v0.1 risk labels map conceptually to v0.2 tiers, but v0.2 Tier 0-3 is the
+  normative model.
+
+Required migration work:
+
+1. Introduce a capability registry with metadata and schemas.
+2. Convert the plan model from `tool + parameters` to `capability + args`.
+3. Add static plan validation and DAG/reference checks.
+4. Add two-phase capability schema validation around reference resolution.
+5. Add argument provenance records.
+6. Replace confirmation-only state with approval records and action
+   fingerprints.
+7. Route execution through controlled adapters with runtime constraints.
+8. Add deterministic secret path denial and pattern redaction.
+9. Expand audit logging from step traces to pipeline-wide records.
+10. Add scenario and invariant tests for the v0.2 acceptance criteria.
+
+## Non-Goals
+
+v0.2 does not provide:
+
+- arbitrary shell execution
+- unrestricted sudo
+- arbitrary SSH or SCP
+- open-ended package installation
+- raw `docker`, `kubectl`, `git`, `python`, `bash`, or `sh` execution
+- autonomous self-approval
+- secret access by default
+- policy decisions delegated to the model
+- model-originated raw command execution
+
+These exclusions are intentional. XFusion v0.2 is agent-assisted, not
+agent-governed.

--- a/tests/test_data_flow.py
+++ b/tests/test_data_flow.py
@@ -96,17 +96,9 @@ def test_failure_when_no_pid_found():
     # Turn 1: execute find_by_port
     state = graph.invoke(state)
 
-    # It should pause for confirmation of kill step.
-    # Policy is deterministic and does not use tool output to skip the gate.
-    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
-
-    # Turn 2: confirm
-    state["user_input"] = state["pending_confirmation_phrase"]
-    state = graph.invoke(state)
-
-    # Resolution should fail because pids[0] is out of bounds
+    # v0.2 fails closed before approval because pids[0] is not an authorized value.
     assert state["plan"].interaction_state == InteractionState.FAILED
-    assert "Parameter resolution failed" in state["response"]
+    assert "Reference resolution failed" in state["response"]
     assert "list index out of range" in state["response"]
 
 
@@ -183,4 +175,7 @@ def test_reference_resolution_error_missing_step():
 
     state = graph.invoke(state)
     assert state["plan"].interaction_state == InteractionState.FAILED
-    assert "Referenced step 'nonexistent_step' output not found" in state["response"]
+    assert "Plan validation failed" in state["response"]
+    assert any(
+        error.code == "legacy_reference_forbidden" for error in state["validation_result"].errors
+    )

--- a/tests/test_plan_correctness.py
+++ b/tests/test_plan_correctness.py
@@ -13,6 +13,8 @@ class MockRegistry:
 
     def execute(self, name, parameters):
         self.executed_tools.append(name)
+        if name == "process.find_by_port":
+            return self.outputs.get(name, ToolOutput(summary="Found", data={"pids": [1234]}))
         return self.outputs.get(name, ToolOutput(summary="Success", data={"ok": True}))
 
 

--- a/tests/test_response_and_audit_contract.py
+++ b/tests/test_response_and_audit_contract.py
@@ -100,8 +100,9 @@ def test_jsonl_audit_file_receives_refusal_records(tmp_path) -> None:
     record = json.loads(lines[-1])
     assert record["plan_id"] == state["plan"].plan_id
     assert record["step_id"] == "delete_path"
-    assert record["action_taken"]["tool"] == "cleanup.safe_disk_cleanup"
-    assert record["status"] == "refused"
+    assert record["action_taken"]["capability"] == "cleanup.safe_disk_cleanup"
+    assert record["status"] == "scope_violation"
+    assert record["action_taken"]["failure_class"] == "scope_violation"
     assert "protected" in record["summary"].lower()
 
 

--- a/tests/test_safety_invariants.py
+++ b/tests/test_safety_invariants.py
@@ -113,7 +113,7 @@ def test_exact_confirmation_phrase_succeeds_and_clears_once() -> None:
     state = confirm_node(state)
 
     assert state.plan is not None
-    assert state.plan.interaction_state == InteractionState.EXECUTING
+    assert state.plan.interaction_state == InteractionState.ABORTED
     assert state.pending_confirmation_phrase is None
     assert state.plan.steps[0].confirmation_phrase is None
 

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -80,6 +80,8 @@ def test_smoke_confirmation_flow():
         plan_id="test-plan",
         goal="stop process",
         language="en",
+        verification_strategy="Verify process termination result.",
+        verification_no_meaningful_verifier=True,
         steps=[
             PlanStep(
                 step_id="kill_it",
@@ -101,7 +103,7 @@ def test_smoke_confirmation_flow():
     state = graph.invoke(state)
     assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
     phrase = state["pending_confirmation_phrase"]
-    assert phrase == "I understand the risks of Kill the process"
+    assert phrase.startswith("APPROVE ")
 
     # Second turn: user confirms with exact phrase
     state["user_input"] = phrase

--- a/tests/test_v02_contracts.py
+++ b/tests/test_v02_contracts.py
@@ -1,0 +1,606 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from pydantic import ValidationError
+
+from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.domain.enums import ApprovalMode, InteractionState, PolicyDecisionValue, RiskTier
+from xfusion.domain.models.capability import CapabilityDefinition, RuntimeConstraints
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+from xfusion.execution.runtime import ControlledAdapterRuntime
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.planning.validator import validate_plan
+from xfusion.policy.rules import evaluate_policy
+from xfusion.security.redaction import redact_value
+from xfusion.tools.base import ToolOutput
+
+
+class MockRegistry:
+    def __init__(self, outputs: dict[str, ToolOutput] | None = None) -> None:
+        self.outputs = outputs or {}
+        self.calls: list[tuple[str, dict[str, object]]] = []
+        self.executed_tools: list[str] = []
+
+    def execute(self, name: str, parameters: dict[str, object]) -> ToolOutput:
+        self.calls.append((name, parameters))
+        self.executed_tools.append(name)
+        return self.outputs.get(name, ToolOutput(summary="ok", data={"ok": True}))
+
+
+def make_graph_state(
+    *,
+    plan: ExecutionPlan,
+    user_input: str = "test",
+) -> dict[str, object]:
+    return {
+        "user_input": user_input,
+        "environment": EnvironmentState(),
+        "language": "en",
+        "plan": plan,
+        "current_step_id": None,
+        "policy_decision": None,
+        "verification_result": None,
+        "last_tool_output": None,
+        "step_outputs": {},
+        "pending_confirmation_phrase": None,
+        "response": "",
+        "audit_records": [],
+    }
+
+
+def test_plan_step_accepts_v02_capability_args_and_preserves_v01_aliases() -> None:
+    step = PlanStep(
+        id="check_disk",
+        capability="disk.check_usage",
+        args={"path": "/"},
+        expected_outputs={"percent_used": "integer"},
+        justification="Inspect disk usage.",
+        verification_method="state_re_read",
+        success_condition="Disk usage is reported.",
+        failure_condition="Disk usage cannot be read.",
+        fallback_action="Report failure.",
+    )
+
+    assert step.step_id == "check_disk"
+    assert step.id == "check_disk"
+    assert step.tool == "disk.check_usage"
+    assert step.capability == "disk.check_usage"
+    assert step.parameters == {"path": "/"}
+    assert step.args == {"path": "/"}
+
+
+def test_plan_step_rejects_unknown_extra_fields() -> None:
+    with pytest.raises(ValidationError):
+        PlanStep.model_validate(
+            {
+                "id": "bad",
+                "capability": "disk.check_usage",
+                "args": {},
+                "expected_outputs": {},
+                "justification": "Bad step.",
+                "verification_method": "state_re_read",
+                "success_condition": "ok",
+                "failure_condition": "fail",
+                "fallback_action": "stop",
+                "hidden_shell": "rm -rf /",
+            }
+        )
+
+
+def test_capability_definition_is_code_defined_and_extra_forbid() -> None:
+    with pytest.raises(ValidationError):
+        CapabilityDefinition(
+            name="unsafe",
+            version=1,
+            verb="execute",
+            object="shell",
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            allowed_environments=["dev"],
+            allowed_actor_types=["assistant"],
+            scope_model={},
+            input_schema={"type": "object"},
+            output_schema={"type": "object"},
+            runtime_constraints=RuntimeConstraints(),
+            adapter_id="unsafe.shell",
+            is_read_only=False,
+            preview_builder="default",
+            verification_recommendation="none",
+            redaction_policy="standard",
+            **{"command": "bash"},
+        )
+
+
+def test_static_validator_denies_unknown_capability_by_default() -> None:
+    plan = ExecutionPlan(
+        plan_id="plan-unknown",
+        goal="test unknown capability",
+        language="en",
+        steps=[
+            PlanStep(
+                id="unknown",
+                capability="shell.run",
+                args={"command": "id"},
+                expected_outputs={},
+                justification="Should be denied.",
+                verification_method="none",
+                success_condition="never",
+                failure_condition="denied",
+                fallback_action="stop",
+            )
+        ],
+    )
+
+    result = validate_plan(plan, build_default_capability_registry())
+
+    assert not result.valid
+    assert any(error.code == "unknown_capability" for error in result.errors)
+
+
+def test_static_validator_rejects_invalid_or_fabricated_reference() -> None:
+    plan = ExecutionPlan(
+        plan_id="plan-ref",
+        goal="bad reference",
+        language="en",
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.locate.outputs.pid", "signal": "TERM"},
+                expected_outputs={"success": "boolean"},
+                justification="Reference missing locate step.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify mutation result",
+    )
+
+    result = validate_plan(plan, build_default_capability_registry())
+
+    assert not result.valid
+    assert any(error.code == "unknown_reference_step" for error in result.errors)
+
+
+def test_static_validator_requires_verification_strategy_for_mutation() -> None:
+    plan = ExecutionPlan(
+        plan_id="plan-mutation",
+        goal="stop a process",
+        language="en",
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"success": "boolean"},
+                justification="Stop bounded process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+    )
+
+    result = validate_plan(plan, build_default_capability_registry())
+
+    assert not result.valid
+    assert any(error.code == "missing_verification_strategy" for error in result.errors)
+
+
+def test_graph_validation_blocks_unknown_capability_before_policy_or_execution() -> None:
+    registry = MockRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="bad-capability",
+        goal="bad capability",
+        language="en",
+        steps=[
+            PlanStep(
+                id="bad",
+                capability="shell.run",
+                args={"command": "id"},
+                expected_outputs={},
+                justification="Should fail validation.",
+                verification_method="none",
+                success_condition="never",
+                failure_condition="denied",
+                fallback_action="stop",
+            )
+        ],
+    )
+
+    result = graph.invoke(make_graph_state(plan=plan))
+
+    assert result["plan"].interaction_state == InteractionState.FAILED
+    assert result["policy_decision"] is None
+    assert registry.executed_tools == []
+    assert "Plan validation failed" in result["response"]
+    assert result["validation_result"].errors[0].code == "unknown_capability"
+
+
+def test_graph_validation_blocks_fabricated_steps_reference_before_execution() -> None:
+    registry = MockRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="bad-ref",
+        goal="bad reference",
+        language="en",
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.locate.outputs.pid"},
+                expected_outputs={"ok": "boolean"},
+                justification="Should fail validation before execution.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify process stop",
+    )
+
+    result = graph.invoke(make_graph_state(plan=plan))
+
+    assert result["plan"].interaction_state == InteractionState.FAILED
+    assert registry.executed_tools == []
+    assert any(
+        error.code == "unknown_reference_step" for error in result["validation_result"].errors
+    )
+
+
+def test_graph_resolves_canonical_steps_reference_at_runtime() -> None:
+    registry = MockRegistry(
+        {
+            "process.find_by_port": ToolOutput(summary="found", data={"pids": [1234]}),
+            "process.kill": ToolOutput(summary="killed", data={"ok": True, "pid": 1234}),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="canonical-ref",
+        goal="stop process on port",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.find.outputs.pids[0]", "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+                verification_step_ids=["verify"],
+            ),
+            PlanStep(
+                id="verify",
+                capability="process.find_by_port",
+                args={"port": 8080, "expect_free": True},
+                depends_on=["kill"],
+                expected_outputs={"pids": "array"},
+                justification="Verify port is free.",
+                verification_method="port_process_recheck",
+                success_condition="Port is free.",
+                failure_condition="Port is busy.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="verify port is free after stopping process",
+    )
+
+    state = graph.invoke(make_graph_state(plan=plan))
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+
+    state["user_input"] = state["pending_confirmation_phrase"]
+    state = graph.invoke(state)
+
+    kill_call = next(call for call in registry.calls if call[0] == "process.kill")
+    assert kill_call[1]["pid"] == 1234
+    assert kill_call[1]["signal"] == "TERM"
+
+
+def test_legacy_ref_dict_is_blocked_before_approval_or_execution() -> None:
+    registry = MockRegistry(
+        {
+            "process.find_by_port": ToolOutput(summary="found", data={"pids": [4321]}),
+            "process.kill": ToolOutput(summary="killed", data={"ok": True, "pid": 4321}),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="legacy-ref",
+        goal="legacy reference",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": {"ref": "find.pids[0]"}},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="legacy references are rejected",
+        verification_no_meaningful_verifier=True,
+    )
+
+    state = graph.invoke(make_graph_state(plan=plan))
+
+    assert state["plan"].interaction_state == InteractionState.FAILED
+    assert state["pending_confirmation_phrase"] is None
+    assert registry.executed_tools == []
+    assert any(
+        error.code == "legacy_reference_forbidden" for error in state["validation_result"].errors
+    )
+
+
+def test_policy_uses_v02_allow_require_approval_deny_decisions() -> None:
+    allowed = evaluate_policy(
+        capability_name="system.service_status",
+        resolved_args={"service": "nginx"},
+        argument_provenance={"service": "literal"},
+        environment=EnvironmentState(),
+    )
+    gated = evaluate_policy(
+        capability_name="process.kill",
+        resolved_args={"pid": 1234, "signal": "TERM"},
+        argument_provenance={"pid": "reference:$steps.find.outputs.pids[0]"},
+        environment=EnvironmentState(),
+    )
+    denied = evaluate_policy(
+        capability_name="shell.run",
+        resolved_args={"command": "id"},
+        argument_provenance={"command": "model"},
+        environment=EnvironmentState(),
+    )
+
+    assert allowed.decision == PolicyDecisionValue.ALLOW
+    assert gated.decision == PolicyDecisionValue.REQUIRE_APPROVAL
+    assert denied.decision == PolicyDecisionValue.DENY
+    assert denied.matched_rule_id == "default.deny_unknown_capability"
+
+
+def test_blocked_secret_read_is_denied_before_execution() -> None:
+    registry = MockRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="secret-read",
+        goal="read a secret",
+        language="en",
+        steps=[
+            PlanStep(
+                id="read_secret",
+                capability="file.read_file",
+                args={"path": "/home/app/.ssh/id_ed25519"},
+                expected_outputs={"content": "string"},
+                justification="Read private key.",
+                verification_method="state_re_read",
+                success_condition="content returned",
+                failure_condition="denied",
+                fallback_action="stop",
+            )
+        ],
+    )
+
+    result = graph.invoke(make_graph_state(plan=plan))
+
+    assert result["plan"].interaction_state == InteractionState.REFUSED
+    assert result["policy_decision"].decision == PolicyDecisionValue.DENY
+    assert "secret" in result["policy_decision"].reason.lower()
+    assert registry.executed_tools == []
+
+
+def test_approval_record_binds_phrase_and_fingerprint() -> None:
+    registry = MockRegistry(
+        {"process.kill": ToolOutput(summary="killed", data={"ok": True, "pid": 1234})}
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="approval-record",
+        goal="stop process",
+        language="en",
+        target_context={"host": "local", "port": 8080},
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"ok": "boolean"},
+                justification="Stop bounded process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify tool success",
+    )
+
+    state = graph.invoke(make_graph_state(plan=plan))
+
+    approval_id = state["pending_approval_id"]
+    approval = state["approval_records"][approval_id]
+    assert approval.action_fingerprint
+    assert approval.typed_confirmation_phrase == state["pending_confirmation_phrase"]
+    assert approval.preview.normalized_args == {"pid": 1234, "signal": "TERM"}
+
+    state["user_input"] = approval.typed_confirmation_phrase
+    state = graph.invoke(state)
+
+    assert state["approval_records"][approval_id].is_approved
+    assert registry.executed_tools == ["process.kill"]
+
+
+def test_stale_approval_invalidates_after_target_change() -> None:
+    registry = MockRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="stale-approval",
+        goal="stop process",
+        language="en",
+        target_context={"host": "local"},
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"ok": "boolean"},
+                justification="Stop bounded process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify tool success",
+    )
+
+    state = graph.invoke(make_graph_state(plan=plan))
+    phrase = state["pending_confirmation_phrase"]
+    state["user_input"] = phrase
+    state = graph.invoke(state)
+    registry.executed_tools.clear()
+
+    # Rewind the approved step to simulate a repaired plan changing the target.
+    state["plan"].steps[0].status = "pending"
+    state["plan"].steps[0].args = {"pid": 9999, "signal": "TERM"}
+    state["plan"].interaction_state = InteractionState.EXECUTING
+    state["plan"].status = "executing"
+    state = graph.invoke(state)
+
+    assert "Approval invalidated" in state["response"]
+    assert registry.executed_tools == []
+
+
+def test_expired_approval_is_rejected() -> None:
+    registry = MockRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="expired-approval",
+        goal="stop process",
+        language="en",
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"ok": "boolean"},
+                justification="Stop bounded process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify tool success",
+    )
+
+    state = graph.invoke(make_graph_state(plan=plan))
+    approval = state["approval_records"][state["pending_approval_id"]]
+    approval.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+    state["user_input"] = state["pending_confirmation_phrase"]
+    state = graph.invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.ABORTED
+    assert "approval_expired" in state["response"]
+
+
+def test_runtime_rejects_free_form_command_arg_and_redacts_output() -> None:
+    capability = build_default_capability_registry().require("system.current_user")
+    rejected = ControlledAdapterRuntime(MockRegistry()).execute(
+        capability=capability,
+        normalized_args={"command": "id"},
+    )
+    assert rejected.status == "runtime_rejected"
+
+    redacted, meta = redact_value(
+        {"stdout": "password=supersecret token=abcdef1234567890 Bearer abcdef1234567890"}
+    )
+    assert "[REDACTED]" in redacted["stdout"]
+    assert meta["redacted"] is True
+
+
+def test_references_resolve_only_from_authorized_upstream_outputs() -> None:
+    registry = MockRegistry(
+        {
+            "process.find_by_port": ToolOutput(summary="found", data={"pids": [1234]}),
+            "process.kill": ToolOutput(summary="killed", data={"ok": True, "pid": 1234}),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="authorized-output",
+        goal="stop process on port",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.find.outputs.pids[0]", "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="verify process stopped",
+        verification_no_meaningful_verifier=True,
+    )
+    state = make_graph_state(plan=plan)
+    state["step_outputs"] = {"find": {"pids": [1234]}}
+
+    result = graph.invoke(state)
+
+    assert result["plan"].steps[0].authorized_output_accepted is True
+    assert result["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION

--- a/tests/test_v02_hardening.py
+++ b/tests/test_v02_hardening.py
@@ -1,12 +1,13 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any
 
 import pytest
 from pydantic import ValidationError
 
 from xfusion.capabilities.registry import build_default_capability_registry
-from xfusion.capabilities.schema import validate_schema_value
+from xfusion.capabilities.schema import SUPPORTED_SCHEMA_KEYWORDS, validate_schema_value
 from xfusion.domain.enums import InteractionState, PolicyDecisionValue, ReasoningRole, StepStatus
 from xfusion.domain.models.environment import EnvironmentState
 from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
@@ -333,6 +334,15 @@ def test_schema_validator_fails_closed_for_unsupported_features() -> None:
 
     assert not result.valid
     assert result.errors == ["$: unsupported schema keyword 'format'"]
+
+
+def test_supported_schema_subset_documentation_matches_validator_keywords() -> None:
+    doc = Path("docs/architecture/schema-subset.md").read_text()
+
+    for keyword in sorted(SUPPORTED_SCHEMA_KEYWORDS):
+        assert f"`{keyword}`" in doc
+    assert "fail closed" in doc
+    assert "xfusion/capabilities/schema.py" in doc
 
 
 def test_malformed_output_is_audited_and_never_becomes_referenceable() -> None:

--- a/tests/test_v02_hardening.py
+++ b/tests/test_v02_hardening.py
@@ -6,9 +6,17 @@ from typing import Any
 import pytest
 from pydantic import ValidationError
 
-from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.capabilities.registry import CapabilityRegistry, build_default_capability_registry
 from xfusion.capabilities.schema import SUPPORTED_SCHEMA_KEYWORDS, validate_schema_value
-from xfusion.domain.enums import InteractionState, PolicyDecisionValue, ReasoningRole, StepStatus
+from xfusion.domain.enums import (
+    ApprovalMode,
+    InteractionState,
+    PolicyDecisionValue,
+    ReasoningRole,
+    RiskTier,
+    StepStatus,
+)
+from xfusion.domain.models.capability import CapabilityDefinition, RuntimeConstraints
 from xfusion.domain.models.environment import EnvironmentState
 from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
 from xfusion.execution.command_runner import CommandResult, CommandRunner
@@ -336,13 +344,88 @@ def test_schema_validator_fails_closed_for_unsupported_features() -> None:
     assert result.errors == ["$: unsupported schema keyword 'format'"]
 
 
-def test_supported_schema_subset_documentation_matches_validator_keywords() -> None:
-    doc = Path("docs/architecture/schema-subset.md").read_text()
+def _test_capability(
+    *,
+    input_schema: dict[str, object],
+    output_schema: dict[str, object] | None = None,
+) -> CapabilityDefinition:
+    return CapabilityDefinition(
+        name="test.capability",
+        version=1,
+        verb="read",
+        object="test",
+        risk_tier=RiskTier.TIER_0,
+        approval_mode=ApprovalMode.AUTO,
+        allowed_environments=["dev"],
+        allowed_actor_types=["assistant"],
+        scope_model={},
+        input_schema=input_schema,
+        output_schema=output_schema or {"type": "object", "additionalProperties": False},
+        runtime_constraints=RuntimeConstraints(),
+        adapter_id="test.capability",
+        is_read_only=True,
+        preview_builder="default",
+        verification_recommendation="none",
+        redaction_policy="standard",
+    )
+
+
+def test_capability_registry_rejects_unsupported_schema_keywords_at_registration() -> None:
+    capability = _test_capability(
+        input_schema={
+            "type": "object",
+            "properties": {"email": {"type": "string", "format": "email"}},
+            "additionalProperties": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="unsupported schema keyword 'format'"):
+        CapabilityRegistry([capability])
+
+
+def test_capability_registry_rejects_malformed_schemas_at_registration() -> None:
+    capability = _test_capability(
+        input_schema={
+            "type": "object",
+            "properties": [],
+            "additionalProperties": False,
+        }
+    )
+
+    with pytest.raises(ValueError, match="properties must be an object"):
+        CapabilityRegistry([capability])
+
+
+def test_capability_schema_documentation_matches_validator_keywords() -> None:
+    doc = Path("docs/architecture/capability-schema.md").read_text()
 
     for keyword in sorted(SUPPORTED_SCHEMA_KEYWORDS):
         assert f"`{keyword}`" in doc
     assert "fail closed" in doc
     assert "xfusion/capabilities/schema.py" in doc
+
+
+def test_docs_make_v02_normative_and_archive_v01_materials() -> None:
+    readme = Path("README.md").read_text()
+    assert "docs/specs/xfusion-v0.2.md" in readme
+    assert "docs/specs/xfusion-v0.1.md" not in readme
+
+    archive_root = Path("docs/archive")
+    archived_docs = sorted(archive_root.rglob("*.md"))
+    assert archived_docs
+    for path in archived_docs:
+        doc = path.read_text()
+        assert doc.startswith("> [!IMPORTANT]\n> Historical, non-normative")
+        assert "docs/specs/xfusion-v0.2.md" in doc
+
+    active_docs = [
+        path
+        for path in Path("docs").rglob("*.md")
+        if "archive" not in path.parts and path != Path("docs/specs/xfusion-v0.2.md")
+    ]
+    for path in active_docs:
+        doc = path.read_text()
+        assert "XFusion v0.1" not in doc
 
 
 def test_malformed_output_is_audited_and_never_becomes_referenceable() -> None:

--- a/tests/test_v02_hardening.py
+++ b/tests/test_v02_hardening.py
@@ -1,0 +1,708 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import ValidationError
+
+from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.capabilities.schema import validate_schema_value
+from xfusion.domain.enums import InteractionState, PolicyDecisionValue, ReasoningRole, StepStatus
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+from xfusion.execution.command_runner import CommandResult, CommandRunner
+from xfusion.execution.runtime import ControlledAdapterRuntime
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.planning.reference_resolver import resolve_args
+from xfusion.planning.validator import validate_plan
+from xfusion.policy.rules import evaluate_policy
+from xfusion.roles.contracts import RoleProposal, validate_role_proposal
+from xfusion.tools.base import ToolOutput
+from xfusion.tools.process import ProcessTools
+from xfusion.tools.system import SystemTools
+
+SECRET = "password=supersecret token=abcdef1234567890"
+
+
+class RaisingRegistry:
+    def execute(self, name: str, parameters: dict[str, object]) -> ToolOutput:
+        raise RuntimeError(f"adapter blew up with {SECRET}")
+
+
+class TimeoutRegistry:
+    def __init__(self) -> None:
+        self.executed_tools: list[str] = []
+
+    def execute(self, name: str, parameters: dict[str, object]) -> ToolOutput:
+        self.executed_tools.append(name)
+        raise TimeoutError(f"runtime exceeded limit while handling {SECRET}")
+
+
+class BrokenReturnRegistry:
+    def __init__(self) -> None:
+        self.executed_tools: list[str] = []
+
+    def execute(self, name: str, parameters: dict[str, object]) -> object:
+        self.executed_tools.append(name)
+        return object()
+
+
+class OutputRegistry:
+    def __init__(self, outputs: dict[str, dict[str, object]]) -> None:
+        self.outputs = outputs
+        self.executed_tools: list[str] = []
+
+    def execute(self, name: str, parameters: dict[str, object]) -> ToolOutput:
+        self.executed_tools.append(name)
+        return ToolOutput(summary="adapter returned test output", data=self.outputs[name])
+
+
+class FakeRunner(CommandRunner):
+    def __init__(self) -> None:
+        self.calls: list[list[str]] = []
+
+    def run(self, command: list[str], **kwargs: object) -> CommandResult:
+        self.calls.append(command)
+        return CommandResult(stdout="operator\n", stderr="", exit_code=0)
+
+
+def test_plan_step_rejects_conflicting_v02_and_legacy_execution_surfaces() -> None:
+    with pytest.raises(ValidationError, match="Conflicting capability/tool"):
+        PlanStep(
+            id="confused",
+            capability="process.kill",
+            tool="system.current_user",
+            args={"pid": 1234, "signal": "TERM"},
+            parameters={},
+            expected_outputs={"ok": "boolean"},
+            justification="Conflicting surfaces must fail closed.",
+            verification_method="command_exit_status_plus_state",
+            success_condition="Process stopped.",
+            failure_condition="Process still running.",
+            fallback_action="stop",
+        )
+
+
+def test_plan_step_rejects_conflicting_v02_and_legacy_argument_surfaces() -> None:
+    with pytest.raises(ValidationError, match="Conflicting args/parameters"):
+        PlanStep(
+            id="confused",
+            capability="process.kill",
+            args={"pid": 1234, "signal": "TERM"},
+            parameters={"pid": 9999, "signal": "TERM"},
+            expected_outputs={"ok": "boolean"},
+            justification="Conflicting arguments must fail closed.",
+            verification_method="command_exit_status_plus_state",
+            success_condition="Process stopped.",
+            failure_condition="Process still running.",
+            fallback_action="stop",
+        )
+
+
+def test_system_current_user_output_matches_registered_contract() -> None:
+    output = SystemTools(FakeRunner()).current_user()
+
+    assert output.data == {"username": "operator"}
+
+
+def test_process_kill_uses_declared_signal_enum_and_structured_success() -> None:
+    runner = FakeRunner()
+    output = ProcessTools(runner).kill(pid=1234, signal="TERM", port=8080)
+
+    assert runner.calls == [["kill", "-TERM", "1234"]]
+    assert output.data == {"ok": True, "pid": 1234, "signal": "TERM", "port": 8080}
+
+
+def test_legacy_ref_dict_is_rejected_by_static_validation_and_resolver() -> None:
+    plan = ExecutionPlan(
+        plan_id="legacy-ref-denied",
+        goal="reject legacy reference",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": {"ref": "find.pids[0]"}, "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="legacy references are unsafe",
+        verification_no_meaningful_verifier=True,
+    )
+
+    result = validate_plan(plan, build_default_capability_registry())
+
+    assert not result.valid
+    assert any(error.code == "legacy_reference_forbidden" for error in result.errors)
+    with pytest.raises(ValueError, match="Legacy reference syntax is forbidden"):
+        resolve_args(
+            plan.steps[1].args,
+            plan=plan,
+            authorized_outputs={"find": {"pids": [1234]}},
+        )
+
+
+def test_registered_capability_schemas_are_closed_objects() -> None:
+    registry = build_default_capability_registry()
+
+    for capability in registry.all():
+        assert capability.input_schema.get("additionalProperties") is False
+        assert capability.output_schema.get("additionalProperties") is False
+
+
+def test_static_validator_rejects_enum_and_range_violations() -> None:
+    plan = ExecutionPlan(
+        plan_id="schema-hardening",
+        goal="reject invalid capability args",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 70000},
+                expected_outputs={"pids": "array"},
+                justification="Invalid port must fail schema validation.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "HUP"},
+                expected_outputs={"ok": "boolean"},
+                justification="Invalid signal must fail schema validation.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="invalid args do not execute",
+        verification_no_meaningful_verifier=True,
+    )
+
+    result = validate_plan(plan, build_default_capability_registry())
+
+    assert not result.valid
+    codes = {error.code for error in result.errors}
+    assert "arg_range_violation" in codes
+    assert "arg_enum_violation" in codes
+
+
+def test_policy_denies_tier0_when_target_scope_is_not_explicit() -> None:
+    decision = evaluate_policy(
+        capability_name="system.service_status",
+        resolved_args={"service": "nginx"},
+        argument_provenance={"service": "literal_or_validated_user_input"},
+        environment=EnvironmentState(),
+        target_scope="implicit",
+    )
+
+    assert decision.decision == PolicyDecisionValue.DENY
+    assert decision.matched_rule_id == "scope.explicit_required"
+    assert "deny_by_default" in decision.reason_codes
+
+
+def test_runtime_normalizes_and_redacts_adapter_exceptions() -> None:
+    capability = build_default_capability_registry().require("system.current_user")
+
+    outcome = ControlledAdapterRuntime(RaisingRegistry()).execute(
+        capability=capability,
+        normalized_args={},
+    )
+
+    assert outcome.status == "adapter_failure"
+    assert outcome.normalized_output["failure_class"] == "adapter_failure"
+    assert "supersecret" not in str(outcome.normalized_output)
+    assert "abcdef1234567890" not in str(outcome.normalized_output)
+    assert outcome.redaction_metadata["redacted"] is True
+
+
+def test_runtime_rejects_output_missing_required_field() -> None:
+    capability = build_default_capability_registry().require("system.current_user")
+
+    outcome = ControlledAdapterRuntime(OutputRegistry({"system.current_user": {}})).execute(
+        capability=capability,
+        normalized_args={},
+    )
+
+    assert outcome.status == "output_schema_validation_failed"
+    assert outcome.normalized_output["failure_class"] == "output_schema_validation_failure"
+    assert "username" in str(outcome.normalized_output["validation_errors"])
+
+
+def test_runtime_rejects_output_with_wrong_type_range_and_enum() -> None:
+    capability = build_default_capability_registry().require("process.kill")
+
+    outcome = ControlledAdapterRuntime(
+        OutputRegistry(
+            {
+                "process.kill": {
+                    "ok": "yes",
+                    "pid": 0,
+                    "signal": "HUP",
+                }
+            }
+        )
+    ).execute(
+        capability=capability,
+        normalized_args={"pid": 1234, "signal": "TERM"},
+    )
+
+    assert outcome.status == "output_schema_validation_failed"
+    errors = " ".join(str(error) for error in outcome.normalized_output["validation_errors"])
+    assert "ok" in errors
+    assert "pid" in errors
+    assert "signal" in errors
+
+
+def test_schema_validator_supports_high_value_json_schema_features() -> None:
+    schema = {
+        "type": "object",
+        "required": ["mode", "items", "meta"],
+        "properties": {
+            "mode": {"const": "safe"},
+            "items": {
+                "type": "array",
+                "minItems": 2,
+                "uniqueItems": True,
+                "contains": {"type": "integer", "minimum": 10},
+                "items": {"anyOf": [{"type": "integer"}, {"type": "string", "pattern": "^ok-"}]},
+            },
+            "meta": {
+                "allOf": [
+                    {
+                        "type": "object",
+                        "required": ["attempts"],
+                        "properties": {"attempts": {"type": "integer", "multipleOf": 2}},
+                        "additionalProperties": {"type": "string"},
+                    },
+                    {"not": {"required": ["secret"]}},
+                ]
+            },
+            "result": {"oneOf": [{"type": "boolean"}, {"type": "null"}]},
+        },
+        "additionalProperties": False,
+    }
+
+    valid = validate_schema_value(
+        {"mode": "safe", "items": [2, "ok-ready", 12], "meta": {"attempts": 4}, "result": None},
+        schema,
+    )
+    invalid = validate_schema_value(
+        {
+            "mode": "unsafe",
+            "items": [2, 2],
+            "meta": {"attempts": 3, "secret": "present"},
+            "result": "yes",
+        },
+        schema,
+    )
+
+    assert valid.valid
+    assert not invalid.valid
+    errors = " ".join(invalid.errors)
+    assert "const" in errors
+    assert "uniqueItems" in errors
+    assert "multipleOf" in errors
+    assert "not schema" in errors
+    assert "oneOf" in errors
+
+
+def test_schema_validator_fails_closed_for_unsupported_features() -> None:
+    result = validate_schema_value("operator@example.com", {"type": "string", "format": "email"})
+
+    assert not result.valid
+    assert result.errors == ["$: unsupported schema keyword 'format'"]
+
+
+def test_malformed_output_is_audited_and_never_becomes_referenceable() -> None:
+    plan = ExecutionPlan(
+        plan_id="malformed-output-flow",
+        goal="reject malformed upstream output",
+        language="en",
+        steps=[
+            PlanStep(
+                id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process.",
+                verification_method="port_process_recheck",
+                success_condition="Port state is reported.",
+                failure_condition="Port lookup fails.",
+                fallback_action="stop",
+            ),
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.find.outputs.pids[0]", "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process from prior output.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            ),
+        ],
+        verification_strategy="verify process stop",
+        verification_no_meaningful_verifier=True,
+    )
+    registry = OutputRegistry({"process.find_by_port": {"pids": "not-a-list", "stdout": ""}})
+    graph = build_agent_graph(registry).compile()
+
+    state = graph.invoke(
+        {
+            "user_input": "reject malformed output",
+            "environment": EnvironmentState(),
+            "language": "en",
+            "plan": plan,
+            "current_step_id": None,
+            "policy_decision": None,
+            "verification_result": None,
+            "last_tool_output": None,
+            "step_outputs": {},
+            "pending_confirmation_phrase": None,
+            "response": "",
+            "audit_records": [],
+        }
+    )
+
+    assert registry.executed_tools == ["process.find_by_port"]
+    assert state["step_outputs"] == {}
+    assert state["authorized_step_outputs"] == {}
+    assert state["plan"].steps[0].authorized_output_accepted is False
+    assert state["plan"].steps[1].status == "pending"
+    assert any(
+        record["status"] == "output_schema_validation_failed" for record in state["audit_records"]
+    )
+    audit_record = next(
+        record
+        for record in state["audit_records"]
+        if record["status"] == "output_schema_validation_failed"
+    )
+    assert audit_record["normalized_output"] == {}
+    assert audit_record["action_taken"]["failure_class"] == "output_schema_validation_failure"
+
+
+def _one_step_graph_state(
+    plan: ExecutionPlan, user_input: str = "fault injection"
+) -> dict[str, Any]:
+    return {
+        "user_input": user_input,
+        "environment": EnvironmentState(),
+        "language": "en",
+        "plan": plan,
+        "current_step_id": None,
+        "policy_decision": None,
+        "verification_result": None,
+        "last_tool_output": None,
+        "step_outputs": {},
+        "authorized_step_outputs": {},
+        "pending_confirmation_phrase": None,
+        "response": "",
+        "audit_records": [],
+    }
+
+
+def _current_user_plan(plan_id: str) -> ExecutionPlan:
+    return ExecutionPlan(
+        plan_id=plan_id,
+        goal="inspect current user",
+        language="en",
+        steps=[
+            PlanStep(
+                id="whoami",
+                capability="system.current_user",
+                args={},
+                expected_outputs={"username": "string"},
+                justification="Read current user.",
+                verification_method="state_re_read",
+                success_condition="User is returned.",
+                failure_condition="User is unavailable.",
+                fallback_action="stop",
+            )
+        ],
+    )
+
+
+def _assert_failure_is_audited_closed(
+    state: dict[str, Any],
+    *,
+    failure_class: str,
+) -> None:
+    assert state["step_outputs"] == {}
+    assert state["authorized_step_outputs"] == {}
+    assert SECRET not in str(state["audit_records"])
+    assert SECRET not in str(state["response"])
+    records = [
+        record
+        for record in state["audit_records"]
+        if isinstance(record, dict) and record.get("status") == failure_class
+    ]
+    assert records
+    record = records[-1]
+    assert record["action_taken"]["failure_class"] == failure_class
+    assert record["normalized_output"] == {}
+    final = state["audit_records"][-1]
+    assert final["event"] == "final_explanation_snapshot"
+    assert final["source_audit_status"] == failure_class
+    assert final["response"] == state["response"]
+
+
+def test_runtime_timeout_fails_closed_end_to_end() -> None:
+    graph = build_agent_graph(TimeoutRegistry()).compile()
+
+    state = graph.invoke(_one_step_graph_state(_current_user_plan("timeout-fault")))
+
+    _assert_failure_is_audited_closed(state, failure_class="runtime_timeout")
+
+
+def test_internal_system_failure_fails_closed_end_to_end() -> None:
+    graph = build_agent_graph(BrokenReturnRegistry()).compile()
+
+    state = graph.invoke(_one_step_graph_state(_current_user_plan("internal-fault")))
+
+    _assert_failure_is_audited_closed(state, failure_class="internal_system_failure")
+
+
+def test_redaction_failure_fails_closed_end_to_end(monkeypatch: pytest.MonkeyPatch) -> None:
+    def broken_redaction(value: object) -> tuple[object, dict[str, object]]:
+        raise RuntimeError(f"redactor unavailable for {SECRET}")
+
+    monkeypatch.setattr("xfusion.execution.runtime.redact_value", broken_redaction)
+    graph = build_agent_graph(
+        OutputRegistry({"system.current_user": {"username": f"operator {SECRET}"}})
+    ).compile()
+
+    state = graph.invoke(_one_step_graph_state(_current_user_plan("redaction-fault")))
+
+    _assert_failure_is_audited_closed(state, failure_class="redaction_failure")
+
+
+def test_scope_violation_fails_closed_end_to_end() -> None:
+    plan = ExecutionPlan(
+        plan_id="scope-violation",
+        goal="mutate protected path",
+        language="en",
+        steps=[
+            PlanStep(
+                id="cleanup",
+                capability="cleanup.safe_disk_cleanup",
+                args={"approved_paths": ["/etc"], "execute": True},
+                expected_outputs={"ok": "boolean"},
+                justification="Protected path mutation must fail closed.",
+                verification_method="filesystem_metadata_recheck",
+                success_condition="Cleanup is bounded.",
+                failure_condition="Protected path was touched.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="protected path denial",
+    )
+    registry = OutputRegistry({"cleanup.safe_disk_cleanup": {"ok": True}})
+    graph = build_agent_graph(registry).compile()
+
+    state = graph.invoke(_one_step_graph_state(plan, user_input=f"cleanup /etc {SECRET}"))
+
+    assert registry.executed_tools == []
+    _assert_failure_is_audited_closed(state, failure_class="scope_violation")
+
+
+def test_reasoning_role_contracts_reject_authority_and_wrong_proposal_types() -> None:
+    forbidden = RoleProposal(
+        role=ReasoningRole.PLANNING,
+        proposal_type="workflow_dag",
+        payload={"capability": "process.kill"},
+        requested_authority=["execute", "approve"],
+    )
+    wrong_type = RoleProposal(
+        role=ReasoningRole.OBSERVATION,
+        proposal_type="workflow_dag",
+        payload={"capability": "process.kill"},
+    )
+    allowed = RoleProposal(
+        role=ReasoningRole.OBSERVATION,
+        proposal_type="tier_0_capability",
+        payload={"capability": "system.current_user", "risk_tier": "tier_0"},
+    )
+
+    forbidden_result = validate_role_proposal(forbidden)
+    wrong_type_result = validate_role_proposal(wrong_type)
+    allowed_result = validate_role_proposal(allowed)
+
+    assert not forbidden_result.valid
+    assert any("non-authoritative" in error for error in forbidden_result.errors)
+    assert not wrong_type_result.valid
+    assert any("not allowed" in error for error in wrong_type_result.errors)
+    assert allowed_result.valid
+
+
+def test_policy_denial_emits_structured_audit_record() -> None:
+    plan = ExecutionPlan(
+        plan_id="policy-denial-audit",
+        goal="explain forbidden action",
+        language="en",
+        steps=[
+            PlanStep(
+                id="deny",
+                capability="plan.explain_action",
+                args={"path": "/etc", "action": "delete"},
+                expected_outputs={"reason": "string"},
+                justification="Unsafe action should be denied.",
+                verification_method="none",
+                success_condition="Denied.",
+                failure_condition="Allowed.",
+                fallback_action="stop",
+            )
+        ],
+    )
+    graph = build_agent_graph(OutputRegistry({})).compile()
+
+    state = graph.invoke(
+        {
+            "user_input": "delete /etc",
+            "environment": EnvironmentState(),
+            "language": "en",
+            "plan": plan,
+            "current_step_id": None,
+            "policy_decision": None,
+            "verification_result": None,
+            "last_tool_output": None,
+            "step_outputs": {},
+            "pending_confirmation_phrase": None,
+            "response": "",
+            "audit_records": [],
+        }
+    )
+
+    audit_record = next(record for record in state["audit_records"] if record.get("status"))
+    assert audit_record["status"] == "policy_denial"
+    assert audit_record["action_taken"]["failure_class"] == "policy_denial"
+    assert audit_record["action_taken"]["policy_decision"]["decision"] == "deny"
+    assert state["audit_records"][-1]["source_audit_status"] == "policy_denial"
+
+
+def test_verification_failure_emits_audit_record_from_authoritative_state() -> None:
+    plan = ExecutionPlan(
+        plan_id="verification-failure-audit",
+        goal="verify port is free",
+        language="en",
+        steps=[
+            PlanStep(
+                id="verify_port",
+                capability="process.find_by_port",
+                args={"port": 8080, "expect_free": True},
+                expected_outputs={"pids": "array"},
+                justification="Check port.",
+                verification_method="port_process_recheck",
+                success_condition="Port is free.",
+                failure_condition="Port is occupied.",
+                fallback_action="stop",
+            )
+        ],
+    )
+    registry = OutputRegistry({"process.find_by_port": {"pids": [1234], "stdout": ""}})
+    graph = build_agent_graph(registry).compile()
+
+    state = graph.invoke(
+        {
+            "user_input": "verify port free",
+            "environment": EnvironmentState(),
+            "language": "en",
+            "plan": plan,
+            "current_step_id": None,
+            "policy_decision": None,
+            "verification_result": None,
+            "last_tool_output": None,
+            "step_outputs": {},
+            "pending_confirmation_phrase": None,
+            "response": "",
+            "audit_records": [],
+        }
+    )
+
+    audit_record = next(record for record in state["audit_records"] if record.get("status"))
+    assert audit_record["status"] == "verification_failure"
+    assert audit_record["verification_result"]["success"] is False
+    assert audit_record["normalized_output"] == {"pids": [1234], "stdout": ""}
+    assert state["audit_records"][-1]["source_audit_status"] == "verification_failure"
+
+
+def test_approval_invalidation_emits_audit_and_blocks_reuse() -> None:
+    plan = ExecutionPlan(
+        plan_id="approval-invalidation-audit",
+        goal="stop process",
+        language="en",
+        steps=[
+            PlanStep(
+                id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"ok": "boolean"},
+                justification="Stop bounded process.",
+                verification_method="command_exit_status_plus_state",
+                success_condition="Process stopped.",
+                failure_condition="Process still running.",
+                fallback_action="stop",
+            )
+        ],
+        verification_strategy="verify process stop",
+    )
+    registry = OutputRegistry({"process.kill": {"ok": True, "pid": 1234, "signal": "TERM"}})
+    graph = build_agent_graph(registry).compile()
+    state = graph.invoke(
+        {
+            "user_input": "stop process",
+            "environment": EnvironmentState(),
+            "language": "en",
+            "plan": plan,
+            "current_step_id": None,
+            "policy_decision": None,
+            "verification_result": None,
+            "last_tool_output": None,
+            "step_outputs": {},
+            "pending_confirmation_phrase": None,
+            "response": "",
+            "audit_records": [],
+        }
+    )
+    state["user_input"] = state["pending_confirmation_phrase"]
+    state = graph.invoke(state)
+    registry.executed_tools.clear()
+
+    state["plan"].steps[0].status = StepStatus.PENDING
+    state["plan"].steps[0].args = {"pid": 9999, "signal": "TERM"}
+    state["plan"].steps[0].parameters = {"pid": 9999, "signal": "TERM"}
+    state["plan"].interaction_state = InteractionState.EXECUTING
+    state["plan"].status = "executing"
+    state = graph.invoke(state)
+
+    assert registry.executed_tools == []
+    audit_record = [
+        record
+        for record in state["audit_records"]
+        if record.get("status") == "approval_invalidated"
+    ][-1]
+    assert audit_record["action_taken"]["failure_class"] == "approval_invalidated"
+    assert state["audit_records"][-1]["source_audit_status"] == "approval_invalidated"

--- a/xfusion/app/cli.py
+++ b/xfusion/app/cli.py
@@ -28,8 +28,8 @@ def main() -> None:
 
     graph = build_agent_graph(registry).compile()
 
-    print("XFusion Guardian v0.1")
-    print("Safety-aware Linux Administration Agent")
+    print("XFusion Guardian v0.2")
+    print("Capability-governed Linux Administration Agent")
     print("-" * 40)
 
     state: dict[str, object] = {

--- a/xfusion/capabilities/__init__.py
+++ b/xfusion/capabilities/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from xfusion.capabilities.registry import CapabilityRegistry, build_default_capability_registry
+
+__all__ = ["CapabilityRegistry", "build_default_capability_registry"]

--- a/xfusion/capabilities/registry.py
+++ b/xfusion/capabilities/registry.py
@@ -1,0 +1,410 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+
+from xfusion.domain.enums import ApprovalMode, RiskTier
+from xfusion.domain.models.capability import CapabilityDefinition, RuntimeConstraints
+
+
+class CapabilityRegistry:
+    """Code-defined registry for v0.2 capabilities."""
+
+    def __init__(self, capabilities: Iterable[CapabilityDefinition]) -> None:
+        self._capabilities = {capability.name: capability for capability in capabilities}
+
+    def has(self, name: str) -> bool:
+        return name in self._capabilities
+
+    def get(self, name: str) -> CapabilityDefinition | None:
+        return self._capabilities.get(name)
+
+    def require(self, name: str) -> CapabilityDefinition:
+        capability = self.get(name)
+        if capability is None:
+            raise KeyError(f"Unknown capability: {name}")
+        return capability
+
+    def all(self) -> tuple[CapabilityDefinition, ...]:
+        return tuple(self._capabilities.values())
+
+
+def _schema(properties: dict[str, object], required: list[str] | None = None) -> dict[str, object]:
+    return {
+        "type": "object",
+        "required": required or [],
+        "properties": properties,
+        "additionalProperties": False,
+    }
+
+
+def _string(*, min_length: int = 1, max_length: int = 256) -> dict[str, object]:
+    return {"type": "string", "minLength": min_length, "maxLength": max_length}
+
+
+def _integer(*, minimum: int, maximum: int) -> dict[str, object]:
+    return {"type": "integer", "minimum": minimum, "maximum": maximum}
+
+
+def _number(*, minimum: float = 0.0, maximum: float = 100.0) -> dict[str, object]:
+    return {"type": "number", "minimum": minimum, "maximum": maximum}
+
+
+def _array(*, max_items: int = 100) -> dict[str, object]:
+    return {"type": "array", "maxItems": max_items}
+
+
+def _bool() -> dict[str, object]:
+    return {"type": "boolean"}
+
+
+def _capability(
+    *,
+    name: str,
+    verb: str,
+    object_name: str,
+    risk_tier: RiskTier,
+    approval_mode: ApprovalMode,
+    is_read_only: bool,
+    input_schema: dict[str, object],
+    output_schema: dict[str, object],
+    adapter_id: str | None = None,
+    verification_recommendation: str = "state_re_read",
+) -> CapabilityDefinition:
+    return CapabilityDefinition(
+        name=name,
+        version=1,
+        verb=verb,
+        object=object_name,
+        risk_tier=risk_tier,
+        approval_mode=approval_mode,
+        allowed_environments=["dev", "staging", "production"],
+        allowed_actor_types=["operator", "assistant"],
+        scope_model={},
+        input_schema=input_schema,
+        output_schema=output_schema,
+        runtime_constraints=RuntimeConstraints(
+            timeout_sec=30.0,
+            max_stdout_bytes=100_000,
+            max_stderr_bytes=100_000,
+            network_access="denied",
+            interactive_tty=False,
+            working_directory=".",
+        ),
+        adapter_id=adapter_id or name,
+        is_read_only=is_read_only,
+        preview_builder="default",
+        verification_recommendation=verification_recommendation,
+        redaction_policy="standard",
+    )
+
+
+def build_default_capability_registry() -> CapabilityRegistry:
+    """Build the code-defined capability registry for the current local adapters."""
+    capabilities = [
+        _capability(
+            name="system.detect_os",
+            verb="read",
+            object_name="environment",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({}),
+            output_schema=_schema(
+                {
+                    "distro_family": _string(),
+                    "distro_version": _string(),
+                    "current_user": _string(),
+                    "sudo_available": _bool(),
+                    "systemd_available": _bool(),
+                    "package_manager": _string(),
+                    "disk_pressure": _string(),
+                    "session_locality": _string(),
+                    "protected_paths": _array(max_items=32),
+                    "active_facts": {"type": "object"},
+                }
+            ),
+        ),
+        _capability(
+            name="system.check_ram",
+            verb="read",
+            object_name="memory",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({}),
+            output_schema=_schema(
+                {
+                    "stdout": _string(min_length=0, max_length=100_000),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+        ),
+        _capability(
+            name="system.current_user",
+            verb="read",
+            object_name="user",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({}),
+            output_schema=_schema({"username": _string()}, ["username"]),
+        ),
+        _capability(
+            name="system.check_sudo",
+            verb="read",
+            object_name="privilege",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({}),
+            output_schema=_schema({"sudo_available": _bool()}),
+        ),
+        _capability(
+            name="system.service_status",
+            verb="read",
+            object_name="service",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({"service": _string(max_length=128)}, ["service"]),
+            output_schema=_schema(
+                {"service": _string(max_length=128), "status": _string(max_length=64)}
+            ),
+        ),
+        _capability(
+            name="disk.check_usage",
+            verb="read",
+            object_name="disk",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({"path": _string(max_length=4096)}, ["path"]),
+            output_schema=_schema(
+                {
+                    "usage_percent": _integer(minimum=0, maximum=100),
+                    "stdout": _string(min_length=0, max_length=100_000),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+        ),
+        _capability(
+            name="disk.find_large_directories",
+            verb="read",
+            object_name="directory",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema(
+                {"path": _string(max_length=4096), "limit": _integer(minimum=1, maximum=100)},
+                ["path"],
+            ),
+            output_schema=_schema(
+                {"items": _array(max_items=100), "error": _string(min_length=0, max_length=100_000)}
+            ),
+        ),
+        _capability(
+            name="file.search",
+            verb="read",
+            object_name="file",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema(
+                {
+                    "query": _string(max_length=256),
+                    "path": _string(max_length=4096),
+                    "limit": _integer(minimum=1, maximum=100),
+                },
+                ["query", "path"],
+            ),
+            output_schema=_schema(
+                {
+                    "matches": _array(max_items=100),
+                    "limit": _integer(minimum=1, maximum=100),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+        ),
+        _capability(
+            name="file.preview_metadata",
+            verb="read",
+            object_name="file_metadata",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({"path": _string(max_length=4096)}, ["path"]),
+            output_schema=_schema(
+                {
+                    "exists": _bool(),
+                    "path": _string(max_length=4096),
+                    "is_dir": _bool(),
+                    "size_bytes": _integer(minimum=0, maximum=10_000_000_000_000),
+                    "mtime": _number(minimum=0, maximum=10_000_000_000),
+                }
+            ),
+        ),
+        _capability(
+            name="file.read_file",
+            verb="read",
+            object_name="file",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema(
+                {
+                    "path": _string(max_length=4096),
+                    "max_bytes": _integer(minimum=1, maximum=1_000_000),
+                },
+                ["path"],
+            ),
+            output_schema=_schema(
+                {
+                    "content": _string(min_length=0, max_length=1_000_000),
+                    "path": _string(max_length=4096),
+                    "truncated": _bool(),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+        ),
+        _capability(
+            name="process.list",
+            verb="read",
+            object_name="process",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema({"limit": _integer(minimum=1, maximum=500)}),
+            output_schema=_schema(
+                {
+                    "processes": _array(max_items=500),
+                    "limit": _integer(minimum=1, maximum=500),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+        ),
+        _capability(
+            name="process.find_by_port",
+            verb="read",
+            object_name="port",
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            is_read_only=True,
+            input_schema=_schema(
+                {"port": _integer(minimum=1, maximum=65535), "expect_free": {"type": "boolean"}},
+                ["port"],
+            ),
+            output_schema=_schema(
+                {
+                    "pids": _array(max_items=128),
+                    "stdout": _string(min_length=0, max_length=100_000),
+                }
+            ),
+            verification_recommendation="port_process_recheck",
+        ),
+        _capability(
+            name="process.kill",
+            verb="terminate",
+            object_name="process",
+            risk_tier=RiskTier.TIER_1,
+            approval_mode=ApprovalMode.HUMAN,
+            is_read_only=False,
+            input_schema=_schema(
+                {
+                    "pid": _integer(minimum=1, maximum=4_194_304),
+                    "signal": {"type": "string", "enum": ["TERM", "KILL"]},
+                    "port": _integer(minimum=1, maximum=65535),
+                },
+                ["pid"],
+            ),
+            output_schema=_schema(
+                {
+                    "ok": _bool(),
+                    "pid": _integer(minimum=1, maximum=4_194_304),
+                    "signal": {"type": "string", "enum": ["TERM", "KILL"]},
+                    "port": _integer(minimum=1, maximum=65535),
+                    "error": _string(min_length=0, max_length=100_000),
+                },
+                ["ok"],
+            ),
+            verification_recommendation="command_exit_status_plus_state",
+        ),
+        _capability(
+            name="user.create",
+            verb="create",
+            object_name="user",
+            risk_tier=RiskTier.TIER_1,
+            approval_mode=ApprovalMode.HUMAN,
+            is_read_only=False,
+            input_schema=_schema({"username": _string(max_length=64)}, ["username"]),
+            output_schema=_schema(
+                {
+                    "username": _string(max_length=64),
+                    "exists": _bool(),
+                    "stdout": _string(min_length=0, max_length=100_000),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+            verification_recommendation="existence_nonexistence_check",
+        ),
+        _capability(
+            name="user.delete",
+            verb="delete",
+            object_name="user",
+            risk_tier=RiskTier.TIER_1,
+            approval_mode=ApprovalMode.HUMAN,
+            is_read_only=False,
+            input_schema=_schema({"username": _string(max_length=64)}, ["username"]),
+            output_schema=_schema(
+                {
+                    "username": _string(max_length=64),
+                    "absent": _bool(),
+                    "error": _string(min_length=0, max_length=100_000),
+                }
+            ),
+            verification_recommendation="existence_nonexistence_check",
+        ),
+        _capability(
+            name="cleanup.safe_disk_cleanup",
+            verb="delete",
+            object_name="cleanup_candidate",
+            risk_tier=RiskTier.TIER_1,
+            approval_mode=ApprovalMode.HUMAN,
+            is_read_only=False,
+            input_schema=_schema(
+                {
+                    "approved_paths": _array(max_items=20),
+                    "candidate_class": _string(max_length=64),
+                    "older_than_days": _integer(minimum=0, maximum=3650),
+                    "max_files": _integer(minimum=1, maximum=10_000),
+                    "max_bytes": _integer(minimum=1, maximum=10_000_000_000),
+                    "execute": {"type": "boolean"},
+                    "path": _string(max_length=4096),
+                }
+            ),
+            output_schema=_schema(
+                {
+                    "previewed_candidates": _array(max_items=10_000),
+                    "deleted": _array(max_items=10_000),
+                    "reclaimed_bytes": _integer(minimum=0, maximum=10_000_000_000),
+                    "ok": _bool(),
+                    "error": _string(min_length=0, max_length=100_000),
+                    "path": _string(max_length=4096),
+                }
+            ),
+            verification_recommendation="filesystem_metadata_recheck",
+        ),
+        _capability(
+            name="plan.explain_action",
+            verb="explain",
+            object_name="policy_refusal",
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            is_read_only=True,
+            input_schema=_schema(
+                {"path": _string(max_length=4096), "action": _string(max_length=64)}
+            ),
+            output_schema=_schema({"reason": _string(max_length=4096)}),
+            verification_recommendation="none",
+        ),
+    ]
+    return CapabilityRegistry(capabilities)

--- a/xfusion/capabilities/registry.py
+++ b/xfusion/capabilities/registry.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 
+from xfusion.capabilities.schema import validate_schema_contract
 from xfusion.domain.enums import ApprovalMode, RiskTier
 from xfusion.domain.models.capability import CapabilityDefinition, RuntimeConstraints
 
@@ -10,7 +11,23 @@ class CapabilityRegistry:
     """Code-defined registry for v0.2 capabilities."""
 
     def __init__(self, capabilities: Iterable[CapabilityDefinition]) -> None:
-        self._capabilities = {capability.name: capability for capability in capabilities}
+        validated_capabilities: dict[str, CapabilityDefinition] = {}
+        errors: list[str] = []
+        for capability in capabilities:
+            if capability.name in validated_capabilities:
+                errors.append(f"{capability.name}: duplicate capability name")
+            for schema_name, schema in (
+                ("input_schema", capability.input_schema),
+                ("output_schema", capability.output_schema),
+            ):
+                result = validate_schema_contract(schema)
+                if not result.valid:
+                    for error in result.errors:
+                        errors.append(f"{capability.name}.{schema_name}: {error}")
+            validated_capabilities[capability.name] = capability
+        if errors:
+            raise ValueError("Invalid capability schema contract: " + "; ".join(errors))
+        self._capabilities = validated_capabilities
 
     def has(self, name: str) -> bool:
         return name in self._capabilities

--- a/xfusion/capabilities/schema.py
+++ b/xfusion/capabilities/schema.py
@@ -1,9 +1,9 @@
-"""Deterministic validator for XFusion capability schema dictionaries.
+"""Deterministic validator for XFusion Capability Schema dictionaries.
 
-This module intentionally implements a documented JSON-Schema-like subset,
-not the full JSON Schema vocabulary. Unsupported keywords fail closed so a
-capability cannot appear to enforce constraints that this validator ignores.
-See docs/architecture/schema-subset.md before extending the subset.
+XFusion Capability Schema is an explicit, frozen v0.2 contract inspired by JSON
+Schema. It is not a general JSON Schema implementation. Unsupported or malformed
+schema features fail closed before capability registration succeeds.
+See docs/architecture/capability-schema.md before extending the contract.
 """
 
 from __future__ import annotations
@@ -46,14 +46,34 @@ SUPPORTED_SCHEMA_KEYWORDS = {
     "$comment",
 }
 
+SUPPORTED_SCHEMA_TYPES = {
+    "object",
+    "array",
+    "string",
+    "integer",
+    "number",
+    "boolean",
+    "null",
+}
+
 
 class SchemaValidationResult(BaseModel):
-    """Deterministic validation result for the supported capability schema subset."""
+    """Deterministic validation result for the XFusion Capability Schema contract."""
 
     model_config = ConfigDict(extra="forbid")
 
     valid: bool
     errors: list[str] = Field(default_factory=list)
+
+
+def validate_schema_contract(
+    schema: dict[str, Any],
+    *,
+    path: str = "$",
+) -> SchemaValidationResult:
+    """Validate a code-defined schema against the XFusion Capability Schema contract."""
+    errors = _schema_contract_errors(schema, path)
+    return SchemaValidationResult(valid=not errors, errors=errors)
 
 
 def validate_schema_value(
@@ -62,14 +82,14 @@ def validate_schema_value(
     *,
     path: str = "$",
 ) -> SchemaValidationResult:
-    """Validate runtime values against the supported capability JSON Schema subset.
+    """Validate runtime values against the XFusion Capability Schema contract.
 
-    Unsupported schema keywords are deterministic failures so code-defined schemas
-    cannot silently claim coverage for constraints this lightweight validator does
+    Unsupported or malformed schemas are deterministic failures so code-defined
+    schemas cannot silently claim coverage for constraints this validator does
     not enforce.
     """
     errors: list[str] = []
-    errors.extend(_unsupported_keyword_errors(schema, path))
+    errors.extend(validate_schema_contract(schema, path=path).errors)
     if errors:
         return SchemaValidationResult(valid=False, errors=errors)
 
@@ -233,28 +253,149 @@ def _validate_combiner(value: Any, schema: dict[str, Any], keyword: str, path: s
     return []
 
 
-def _unsupported_keyword_errors(schema: dict[str, Any], path: str) -> list[str]:
-    errors = [
+def _schema_contract_errors(schema: dict[str, Any], path: str) -> list[str]:
+    errors: list[str] = [
         f"{path}: unsupported schema keyword {key!r}"
         for key in schema
         if key not in SUPPORTED_SCHEMA_KEYWORDS
     ]
-    for key, nested in schema.get("properties", {}).items():
-        if isinstance(nested, dict):
-            errors.extend(_unsupported_keyword_errors(nested, f"{path}.{key}"))
+
+    expected_type = schema.get("type")
+    if expected_type is not None:
+        errors.extend(_type_contract_errors(expected_type, path))
+
+    properties = schema.get("properties")
+    if properties is not None:
+        if not isinstance(properties, dict):
+            errors.append(f"{path}.properties: properties must be an object")
+        else:
+            for key, nested in properties.items():
+                if not isinstance(key, str):
+                    errors.append(f"{path}.properties: property names must be strings")
+                    continue
+                if not isinstance(nested, dict):
+                    errors.append(f"{path}.{key}: property schema must be an object")
+                    continue
+                errors.extend(_schema_contract_errors(nested, f"{path}.{key}"))
+
+    required = schema.get("required")
+    if required is not None and (
+        not isinstance(required, list) or not all(isinstance(item, str) for item in required)
+    ):
+        errors.append(f"{path}.required: required must be a list of strings")
+
+    enum_values = schema.get("enum")
+    if enum_values is not None and not isinstance(enum_values, list):
+        errors.append(f"{path}.enum: enum must be a list")
+
+    pattern = schema.get("pattern")
+    if pattern is not None:
+        if not isinstance(pattern, str):
+            errors.append(f"{path}.pattern: pattern must be a string")
+        else:
+            try:
+                re.compile(pattern)
+            except re.error as exc:
+                errors.append(f"{path}.pattern: invalid pattern {pattern!r}: {exc}")
+
+    additional_properties = schema.get("additionalProperties")
+    if additional_properties is not None and not isinstance(additional_properties, bool | dict):
+        errors.append(
+            f"{path}.additionalProperties: additionalProperties must be a boolean or schema"
+        )
+
+    for keyword in (
+        "minItems",
+        "maxItems",
+        "minContains",
+        "maxContains",
+        "minLength",
+        "maxLength",
+        "minProperties",
+        "maxProperties",
+    ):
+        value = schema.get(keyword)
+        if value is not None and (
+            not isinstance(value, int) or isinstance(value, bool) or value < 0
+        ):
+            errors.append(f"{path}.{keyword}: {keyword} must be a non-negative integer")
+
+    unique_items = schema.get("uniqueItems")
+    if unique_items is not None and not isinstance(unique_items, bool):
+        errors.append(f"{path}.uniqueItems: uniqueItems must be a boolean")
+
+    for keyword in ("minimum", "maximum", "exclusiveMinimum", "exclusiveMaximum", "multipleOf"):
+        value = schema.get(keyword)
+        if value is not None and (not isinstance(value, int | float) or isinstance(value, bool)):
+            errors.append(f"{path}.{keyword}: {keyword} must be a number")
+    multiple_of = schema.get("multipleOf")
+    if (
+        isinstance(multiple_of, int | float)
+        and not isinstance(multiple_of, bool)
+        and multiple_of <= 0
+    ):
+        errors.append(f"{path}.multipleOf: multipleOf must be greater than zero")
+
     for keyword in ("items", "additionalProperties", "contains", "not"):
         nested = schema.get(keyword)
         if isinstance(nested, dict):
-            errors.extend(_unsupported_keyword_errors(nested, path))
+            errors.extend(_schema_contract_errors(nested, f"{path}.{keyword}"))
+        elif keyword in schema and keyword in {"items", "contains", "not"}:
+            errors.append(f"{path}.{keyword}: {keyword} must be a schema object")
+
     for keyword in ("allOf", "anyOf", "oneOf"):
         nested_list = schema.get(keyword)
-        if isinstance(nested_list, list):
-            for index, nested in enumerate(nested_list):
-                if isinstance(nested, dict):
-                    nested_schema = cast(dict[str, Any], nested)
-                    errors.extend(
-                        _unsupported_keyword_errors(nested_schema, f"{path}.{keyword}[{index}]")
-                    )
+        if nested_list is None:
+            continue
+        if not isinstance(nested_list, list) or not nested_list:
+            errors.append(f"{path}.{keyword}: {keyword} must be a non-empty list of schemas")
+            continue
+        for index, nested in enumerate(nested_list):
+            if not isinstance(nested, dict):
+                errors.append(f"{path}.{keyword}[{index}]: schema must be an object")
+                continue
+            nested_schema = cast(dict[str, Any], nested)
+            errors.extend(_schema_contract_errors(nested_schema, f"{path}.{keyword}[{index}]"))
+
+    errors.extend(_bound_order_errors(schema, path))
+    return errors
+
+
+def _type_contract_errors(expected_type: object, path: str) -> list[str]:
+    if isinstance(expected_type, str):
+        if expected_type not in SUPPORTED_SCHEMA_TYPES:
+            return [f"{path}.type: unsupported type {expected_type!r}"]
+        return []
+    if isinstance(expected_type, list) and expected_type:
+        errors: list[str] = []
+        for index, item in enumerate(expected_type):
+            if not isinstance(item, str) or item not in SUPPORTED_SCHEMA_TYPES:
+                errors.append(f"{path}.type[{index}]: unsupported type {item!r}")
+        return errors
+    return [f"{path}.type: type must be a string or non-empty list of strings"]
+
+
+def _bound_order_errors(schema: dict[str, Any], path: str) -> list[str]:
+    errors: list[str] = []
+    bound_pairs = (
+        ("minItems", "maxItems"),
+        ("minLength", "maxLength"),
+        ("minProperties", "maxProperties"),
+        ("minimum", "maximum"),
+        ("exclusiveMinimum", "exclusiveMaximum"),
+        ("minContains", "maxContains"),
+    )
+    for lower_name, upper_name in bound_pairs:
+        lower = schema.get(lower_name)
+        upper = schema.get(upper_name)
+        if (
+            isinstance(lower, int | float)
+            and isinstance(upper, int | float)
+            and not isinstance(lower, bool)
+            and not isinstance(upper, bool)
+            and lower > upper
+        ):
+            errors.append(f"{path}: {lower_name} must be less than or equal to {upper_name}")
     return errors
 
 

--- a/xfusion/capabilities/schema.py
+++ b/xfusion/capabilities/schema.py
@@ -1,3 +1,11 @@
+"""Deterministic validator for XFusion capability schema dictionaries.
+
+This module intentionally implements a documented JSON-Schema-like subset,
+not the full JSON Schema vocabulary. Unsupported keywords fail closed so a
+capability cannot appear to enforce constraints that this validator ignores.
+See docs/architecture/schema-subset.md before extending the subset.
+"""
+
 from __future__ import annotations
 
 import re
@@ -40,7 +48,7 @@ SUPPORTED_SCHEMA_KEYWORDS = {
 
 
 class SchemaValidationResult(BaseModel):
-    """Deterministic validation result for capability JSON-schema subsets."""
+    """Deterministic validation result for the supported capability schema subset."""
 
     model_config = ConfigDict(extra="forbid")
 

--- a/xfusion/capabilities/schema.py
+++ b/xfusion/capabilities/schema.py
@@ -1,0 +1,299 @@
+from __future__ import annotations
+
+import re
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+SUPPORTED_SCHEMA_KEYWORDS = {
+    "type",
+    "enum",
+    "const",
+    "properties",
+    "required",
+    "additionalProperties",
+    "items",
+    "minItems",
+    "maxItems",
+    "uniqueItems",
+    "contains",
+    "minContains",
+    "maxContains",
+    "minLength",
+    "maxLength",
+    "pattern",
+    "minimum",
+    "maximum",
+    "exclusiveMinimum",
+    "exclusiveMaximum",
+    "multipleOf",
+    "minProperties",
+    "maxProperties",
+    "allOf",
+    "anyOf",
+    "oneOf",
+    "not",
+    "description",
+    "title",
+    "$comment",
+}
+
+
+class SchemaValidationResult(BaseModel):
+    """Deterministic validation result for capability JSON-schema subsets."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    errors: list[str] = Field(default_factory=list)
+
+
+def validate_schema_value(
+    value: Any,
+    schema: dict[str, Any],
+    *,
+    path: str = "$",
+) -> SchemaValidationResult:
+    """Validate runtime values against the supported capability JSON Schema subset.
+
+    Unsupported schema keywords are deterministic failures so code-defined schemas
+    cannot silently claim coverage for constraints this lightweight validator does
+    not enforce.
+    """
+    errors: list[str] = []
+    errors.extend(_unsupported_keyword_errors(schema, path))
+    if errors:
+        return SchemaValidationResult(valid=False, errors=errors)
+
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        nested_errors = _validate_combiner(value, schema, keyword, path)
+        if nested_errors:
+            errors.extend(nested_errors)
+
+    not_schema = schema.get("not")
+    if isinstance(not_schema, dict):
+        result = validate_schema_value(value, not_schema, path=path)
+        if result.valid:
+            errors.append(f"{path}: value matched forbidden not schema")
+
+    expected_type = schema.get("type")
+
+    if expected_type and not _type_matches(value, expected_type):
+        errors.append(f"{path}: expected {expected_type}, got {_value_type(value)}")
+        return SchemaValidationResult(valid=False, errors=errors)
+
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and value not in enum_values:
+        errors.append(f"{path}: value {value!r} is not one of {enum_values!r}")
+
+    if "const" in schema and value != schema["const"]:
+        errors.append(f"{path}: value {value!r} does not match const {schema['const']!r}")
+
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        exclusive_minimum = schema.get("exclusiveMinimum")
+        exclusive_maximum = schema.get("exclusiveMaximum")
+        multiple_of = schema.get("multipleOf")
+        if isinstance(minimum, int | float) and value < minimum:
+            errors.append(f"{path}: value {value!r} is below minimum {minimum!r}")
+        if isinstance(maximum, int | float) and value > maximum:
+            errors.append(f"{path}: value {value!r} is above maximum {maximum!r}")
+        if isinstance(exclusive_minimum, int | float) and value <= exclusive_minimum:
+            errors.append(
+                f"{path}: value {value!r} is not above exclusiveMinimum {exclusive_minimum!r}"
+            )
+        if isinstance(exclusive_maximum, int | float) and value >= exclusive_maximum:
+            errors.append(
+                f"{path}: value {value!r} is not below exclusiveMaximum {exclusive_maximum!r}"
+            )
+        if isinstance(multiple_of, int | float) and multiple_of > 0:
+            quotient = value / multiple_of
+            if abs(quotient - round(quotient)) > 1e-9:
+                errors.append(f"{path}: value {value!r} is not a multipleOf {multiple_of!r}")
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        max_length = schema.get("maxLength")
+        pattern = schema.get("pattern")
+        if isinstance(min_length, int) and len(value) < min_length:
+            errors.append(f"{path}: string is shorter than minLength {min_length}")
+        if isinstance(max_length, int) and len(value) > max_length:
+            errors.append(f"{path}: string is longer than maxLength {max_length}")
+        if isinstance(pattern, str):
+            try:
+                if re.search(pattern, value) is None:
+                    errors.append(f"{path}: string does not match pattern {pattern!r}")
+            except re.error as exc:
+                errors.append(f"{path}: invalid pattern {pattern!r}: {exc}")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        max_items = schema.get("maxItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            errors.append(f"{path}: array has fewer than minItems {min_items}")
+        if isinstance(max_items, int) and len(value) > max_items:
+            errors.append(f"{path}: array has more than maxItems {max_items}")
+        if schema.get("uniqueItems") is True and not _items_are_unique(value):
+            errors.append(f"{path}: array items are not uniqueItems")
+        item_schema = schema.get("items")
+        if isinstance(item_schema, dict):
+            for index, item in enumerate(value):
+                nested = validate_schema_value(item, item_schema, path=f"{path}[{index}]")
+                errors.extend(nested.errors)
+        contains_schema = schema.get("contains")
+        if isinstance(contains_schema, dict):
+            match_count = 0
+            contains_errors: list[str] = []
+            for index, item in enumerate(value):
+                nested = validate_schema_value(item, contains_schema, path=f"{path}[{index}]")
+                if nested.valid:
+                    match_count += 1
+                else:
+                    contains_errors.extend(nested.errors)
+            min_contains = schema.get("minContains", 1)
+            max_contains = schema.get("maxContains")
+            if isinstance(min_contains, int) and match_count < min_contains:
+                errors.append(
+                    f"{path}: array contains {match_count} matching item(s), below {min_contains}"
+                )
+            if isinstance(max_contains, int) and match_count > max_contains:
+                errors.append(
+                    f"{path}: array contains {match_count} matching item(s), above {max_contains}"
+                )
+
+    if isinstance(value, dict):
+        properties = schema.get("properties")
+        required = schema.get("required")
+        if not isinstance(properties, dict):
+            properties = {}
+        if not isinstance(required, list):
+            required = []
+
+        min_properties = schema.get("minProperties")
+        max_properties = schema.get("maxProperties")
+        if isinstance(min_properties, int) and len(value) < min_properties:
+            errors.append(f"{path}: object has fewer than minProperties {min_properties}")
+        if isinstance(max_properties, int) and len(value) > max_properties:
+            errors.append(f"{path}: object has more than maxProperties {max_properties}")
+
+        for required_name in required:
+            if str(required_name) not in value:
+                errors.append(f"{path}.{required_name}: missing required field")
+
+        additional_properties = schema.get("additionalProperties")
+        if additional_properties is False:
+            for key in value:
+                if key not in properties:
+                    errors.append(f"{path}.{key}: additional properties are forbidden")
+        elif isinstance(additional_properties, dict):
+            for key, item in value.items():
+                if key in properties:
+                    continue
+                nested = validate_schema_value(item, additional_properties, path=f"{path}.{key}")
+                errors.extend(nested.errors)
+
+        for key, nested_schema in properties.items():
+            if key not in value or not isinstance(nested_schema, dict):
+                continue
+            nested = validate_schema_value(value[key], nested_schema, path=f"{path}.{key}")
+            errors.extend(nested.errors)
+
+    return SchemaValidationResult(valid=not errors, errors=errors)
+
+
+def _validate_combiner(value: Any, schema: dict[str, Any], keyword: str, path: str) -> list[str]:
+    candidates = schema.get(keyword)
+    if candidates is None:
+        return []
+    if not isinstance(candidates, list) or not all(isinstance(item, dict) for item in candidates):
+        return [f"{path}: {keyword} must be a list of schemas"]
+
+    results = [
+        validate_schema_value(value, candidate, path=path)
+        for candidate in candidates
+        if isinstance(candidate, dict)
+    ]
+    valid_count = sum(1 for result in results if result.valid)
+    if keyword == "allOf" and valid_count != len(results):
+        detail = "; ".join(error for result in results for error in result.errors)
+        return [f"{path}: value failed allOf ({detail})"]
+    if keyword == "anyOf" and valid_count < 1:
+        return [f"{path}: value failed anyOf"]
+    if keyword == "oneOf" and valid_count != 1:
+        return [f"{path}: value matched {valid_count} oneOf schemas"]
+    return []
+
+
+def _unsupported_keyword_errors(schema: dict[str, Any], path: str) -> list[str]:
+    errors = [
+        f"{path}: unsupported schema keyword {key!r}"
+        for key in schema
+        if key not in SUPPORTED_SCHEMA_KEYWORDS
+    ]
+    for key, nested in schema.get("properties", {}).items():
+        if isinstance(nested, dict):
+            errors.extend(_unsupported_keyword_errors(nested, f"{path}.{key}"))
+    for keyword in ("items", "additionalProperties", "contains", "not"):
+        nested = schema.get(keyword)
+        if isinstance(nested, dict):
+            errors.extend(_unsupported_keyword_errors(nested, path))
+    for keyword in ("allOf", "anyOf", "oneOf"):
+        nested_list = schema.get(keyword)
+        if isinstance(nested_list, list):
+            for index, nested in enumerate(nested_list):
+                if isinstance(nested, dict):
+                    nested_schema = cast(dict[str, Any], nested)
+                    errors.extend(
+                        _unsupported_keyword_errors(nested_schema, f"{path}.{keyword}[{index}]")
+                    )
+    return errors
+
+
+def _type_matches(value: Any, expected_type: object) -> bool:
+    if isinstance(expected_type, list):
+        return any(isinstance(item, str) and _type_matches(value, item) for item in expected_type)
+    if not isinstance(expected_type, str):
+        return True
+    if expected_type == "object":
+        return isinstance(value, dict)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "null":
+        return value is None
+    return False
+
+
+def _items_are_unique(value: list[Any]) -> bool:
+    seen: list[Any] = []
+    for item in value:
+        if item in seen:
+            return False
+        seen.append(item)
+    return True
+
+
+def _value_type(value: Any) -> str:
+    if isinstance(value, bool):
+        return "boolean"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, list):
+        return "array"
+    if isinstance(value, dict):
+        return "object"
+    if value is None:
+        return "null"
+    return type(value).__name__

--- a/xfusion/domain/enums.py
+++ b/xfusion/domain/enums.py
@@ -28,3 +28,55 @@ class RiskLevel(StrEnum):
     MEDIUM = "medium"
     HIGH = "high"
     FORBIDDEN = "forbidden"
+
+
+class RiskTier(StrEnum):
+    TIER_0 = "tier_0"
+    TIER_1 = "tier_1"
+    TIER_2 = "tier_2"
+    TIER_3 = "tier_3"
+
+
+class ApprovalMode(StrEnum):
+    AUTO = "auto"
+    HUMAN = "human"
+    ADMIN = "admin"
+    DENY = "deny"
+
+
+class PolicyDecisionValue(StrEnum):
+    ALLOW = "allow"
+    REQUIRE_APPROVAL = "require_approval"
+    DENY = "deny"
+
+
+class ReasoningRole(StrEnum):
+    SUPERVISOR = "supervisor"
+    OBSERVATION = "observation"
+    DIAGNOSIS = "diagnosis"
+    PLANNING = "planning"
+    VERIFICATION = "verification"
+    EXPLANATION = "explanation"
+
+
+class VerificationStatus(StrEnum):
+    SUCCESS = "success"
+    PARTIAL_SUCCESS = "partial_success"
+    FAILED = "failed"
+    INCONCLUSIVE = "inconclusive"
+
+
+class FailureClass(StrEnum):
+    VALIDATION_FAILURE = "validation_failure"
+    POLICY_DENIAL = "policy_denial"
+    APPROVAL_PENDING = "approval_pending"
+    APPROVAL_DENIED = "approval_denied"
+    APPROVAL_EXPIRED = "approval_expired"
+    ADAPTER_FAILURE = "adapter_failure"
+    EXECUTION_FAILURE = "execution_failure"
+    OUTPUT_SCHEMA_VALIDATION_FAILURE = "output_schema_validation_failure"
+    RUNTIME_TIMEOUT = "runtime_timeout"
+    SCOPE_VIOLATION = "scope_violation"
+    REDACTION_FAILURE = "redaction_failure"
+    VERIFICATION_FAILURE = "verification_failure"
+    INTERNAL_SYSTEM_FAILURE = "internal_system_failure"

--- a/xfusion/domain/models/approval.py
+++ b/xfusion/domain/models/approval.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from xfusion.domain.enums import ApprovalMode, RiskTier
+
+
+class PreviewPayload(BaseModel):
+    """Operator-visible preview for an approval-gated capability invocation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    impacted_target: str
+    action_summary: str
+    reversibility_estimate: str
+    expected_blast_radius: str
+    capability: str
+    normalized_args: dict[str, Any]
+    argument_provenance_summary: dict[str, str]
+    rollback_notes: str | None = None
+    approval_mode: ApprovalMode
+    expiry: datetime
+
+
+class ApprovalRecord(BaseModel):
+    """Typed approval bound to a deterministic action fingerprint."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    approval_id: str = Field(min_length=1)
+    plan_id: str = Field(min_length=1)
+    step_id: str = Field(min_length=1)
+    normalized_capability_set: list[str] = Field(min_length=1)
+    target_context: dict[str, Any]
+    action_fingerprint: str = Field(min_length=1)
+    referenced_output_fingerprints: dict[str, str] = Field(default_factory=dict)
+    approval_mode: ApprovalMode
+    risk_tier: RiskTier
+    adapter_id: str = Field(min_length=1)
+    capability_version: int = Field(ge=1)
+    preview: PreviewPayload
+    typed_confirmation_phrase: str = Field(min_length=1)
+    created_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+    expires_at: datetime = Field(default_factory=lambda: datetime.now(UTC) + timedelta(minutes=10))
+    approved_at: datetime | None = None
+    invalidated_at: datetime | None = None
+    invalidation_reason: str | None = None
+
+    @property
+    def is_approved(self) -> bool:
+        return self.approved_at is not None and self.invalidated_at is None
+
+    def is_expired(self, now: datetime | None = None) -> bool:
+        check_time = now or datetime.now(UTC)
+        return check_time >= self.expires_at

--- a/xfusion/domain/models/capability.py
+++ b/xfusion/domain/models/capability.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from xfusion.domain.enums import ApprovalMode, RiskTier
+
+
+class RuntimeConstraints(BaseModel):
+    """Deterministic runtime limits for one capability adapter."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    timeout_sec: float = Field(default=30.0, gt=0)
+    max_stdout_bytes: int = Field(default=100_000, ge=0)
+    max_stderr_bytes: int = Field(default=100_000, ge=0)
+    network_access: str = "denied"
+    interactive_tty: bool = False
+    working_directory: str = "."
+
+
+class CapabilityDefinition(BaseModel):
+    """Code-defined v0.2 capability contract."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    name: str = Field(min_length=1)
+    version: int = Field(ge=1)
+    verb: str = Field(min_length=1)
+    object: str = Field(min_length=1)
+    risk_tier: RiskTier
+    approval_mode: ApprovalMode
+    allowed_environments: list[str] = Field(default_factory=list)
+    allowed_actor_types: list[str] = Field(default_factory=list)
+    scope_model: dict[str, Any] = Field(default_factory=dict)
+    input_schema: dict[str, Any] = Field(default_factory=dict)
+    output_schema: dict[str, Any] = Field(default_factory=dict)
+    runtime_constraints: RuntimeConstraints = Field(default_factory=RuntimeConstraints)
+    adapter_id: str = Field(min_length=1)
+    is_read_only: bool
+    preview_builder: str = Field(min_length=1)
+    verification_recommendation: str = Field(min_length=1)
+    redaction_policy: str = Field(min_length=1)

--- a/xfusion/domain/models/execution_plan.py
+++ b/xfusion/domain/models/execution_plan.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field, model_validator
 
-from xfusion.domain.enums import InteractionState, RiskLevel, StepStatus
+from xfusion.domain.enums import ApprovalMode, InteractionState, RiskLevel, RiskTier, StepStatus
 
 
 class PlanStep(BaseModel):
@@ -10,20 +12,124 @@ class PlanStep(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    step_id: str = Field(min_length=1)
-    intent: str = Field(min_length=1)
-    tool: str = Field(min_length=1)
+    step_id: str = Field(default="", min_length=0)
+    id: str | None = Field(default=None, min_length=1)
+    intent: str = Field(default="", min_length=0)
+    capability: str | None = Field(default=None, min_length=1)
+    tool: str = Field(default="", min_length=0)
+    args: dict[str, object] = Field(default_factory=dict)
     parameters: dict[str, object] = Field(default_factory=dict)
+    depends_on: list[str] = Field(default_factory=list)
     dependencies: list[str] = Field(default_factory=list)
+    expected_outputs: dict[str, object] = Field(default_factory=dict)
+    justification: str = ""
+    risk_hint: RiskTier | None = None
+    approval_required_hint: ApprovalMode | None = None
+    preview_summary: str = ""
+    on_failure: str = ""
+    verification_step_ids: list[str] = Field(default_factory=list)
     risk_level: RiskLevel = RiskLevel.LOW
     requires_confirmation: bool = False
     confirmation_phrase: str | None = None
-    expected_output: str = Field(min_length=1)
+    approval_id: str | None = None
+    action_fingerprint: str | None = None
+    normalized_args: dict[str, object] = Field(default_factory=dict)
+    argument_provenance: dict[str, str] = Field(default_factory=dict)
+    resolved_references: dict[str, object] = Field(default_factory=dict)
+    adapter_id: str | None = None
+    policy_rule_id: str | None = None
+    approval_mode: ApprovalMode | None = None
+    authorized_output_accepted: bool = False
+    failure_class: str | None = None
+    failure_details: dict[str, object] = Field(default_factory=dict)
+    redaction_metadata: dict[str, object] = Field(default_factory=dict)
+    expected_output: str = Field(default="Structured capability output.", min_length=1)
     verification_method: str = Field(min_length=1)
     success_condition: str = Field(min_length=1)
     failure_condition: str = Field(min_length=1)
     fallback_action: str = Field(min_length=1)
     status: StepStatus = StepStatus.PENDING
+
+    @model_validator(mode="before")
+    @classmethod
+    def normalize_v02_aliases(cls, data: Any) -> Any:
+        """Normalize v0.2 fields without allowing conflicting legacy surfaces."""
+        if not isinstance(data, dict):
+            return data
+
+        normalized = dict(data)
+        if (
+            normalized.get("capability") is not None
+            and normalized.get("tool") is not None
+            and normalized["capability"] != normalized["tool"]
+        ):
+            raise ValueError("Conflicting capability/tool values are not allowed.")
+        if (
+            "args" in normalized
+            and "parameters" in normalized
+            and normalized["args"] != normalized["parameters"]
+        ):
+            raise ValueError("Conflicting args/parameters values are not allowed.")
+        if (
+            "depends_on" in normalized
+            and "dependencies" in normalized
+            and normalized["depends_on"] != normalized["dependencies"]
+        ):
+            raise ValueError("Conflicting depends_on/dependencies values are not allowed.")
+
+        if normalized.get("step_id") is None and normalized.get("id") is not None:
+            normalized["step_id"] = normalized["id"]
+        if normalized.get("id") is None and normalized.get("step_id") is not None:
+            normalized["id"] = normalized["step_id"]
+
+        if normalized.get("tool") is None and normalized.get("capability") is not None:
+            normalized["tool"] = normalized["capability"]
+        if normalized.get("capability") is None and normalized.get("tool") is not None:
+            normalized["capability"] = normalized["tool"]
+
+        if "parameters" not in normalized and "args" in normalized:
+            normalized["parameters"] = normalized["args"]
+        if "args" not in normalized and "parameters" in normalized:
+            normalized["args"] = normalized["parameters"]
+
+        if "dependencies" not in normalized and "depends_on" in normalized:
+            normalized["dependencies"] = normalized["depends_on"]
+        if "depends_on" not in normalized and "dependencies" in normalized:
+            normalized["depends_on"] = normalized["dependencies"]
+
+        if not normalized.get("intent"):
+            normalized["intent"] = (
+                normalized.get("justification") or normalized.get("step_id") or "step"
+            )
+
+        if "expected_output" not in normalized and "expected_outputs" in normalized:
+            normalized["expected_output"] = "Structured capability output."
+        if "on_failure" not in normalized and "fallback_action" in normalized:
+            normalized["on_failure"] = str(normalized["fallback_action"])
+
+        return normalized
+
+    @model_validator(mode="after")
+    def validate_v02_aliases(self) -> PlanStep:
+        """Ensure canonical v0.2 and transitional aliases stay identical."""
+        if not self.step_id or not self.id:
+            raise ValueError("Step requires id/step_id.")
+        if not self.tool or not self.capability:
+            raise ValueError("Step requires capability/tool.")
+        if self.capability != self.tool:
+            raise ValueError("Conflicting capability/tool values are not allowed.")
+        if self.args != self.parameters:
+            raise ValueError("Conflicting args/parameters values are not allowed.")
+        if self.depends_on != self.dependencies:
+            raise ValueError("Conflicting depends_on/dependencies values are not allowed.")
+
+        self.id = self.step_id
+        self.capability = self.tool
+        self.args = dict(self.parameters)
+        self.depends_on = list(self.dependencies)
+        if not self.on_failure:
+            self.on_failure = self.fallback_action
+        return self
 
 
 class ExecutionPlan(BaseModel):
@@ -40,6 +146,15 @@ class ExecutionPlan(BaseModel):
     current_step: str | None = None
     status: str = "executing"
     clarification_question: str | None = None
+    intent_class: str = "operation"
+    target_context: dict[str, object] = Field(default_factory=dict)
+    created_by: str = "xfusion"
+    created_at: str | None = None
+    assumptions: list[str] = Field(default_factory=list)
+    safety_notes: list[str] = Field(default_factory=list)
+    approval_summary: dict[str, object] = Field(default_factory=dict)
+    verification_strategy: str | None = None
+    verification_no_meaningful_verifier: bool = False
 
     @model_validator(mode="after")
     def validate_dependencies(self) -> ExecutionPlan:

--- a/xfusion/domain/models/policy.py
+++ b/xfusion/domain/models/policy.py
@@ -1,16 +1,54 @@
 from __future__ import annotations
 
+from typing import Any
+
 from pydantic import BaseModel, ConfigDict, Field
 
-from xfusion.domain.enums import RiskLevel
+from xfusion.domain.enums import ApprovalMode, PolicyDecisionValue, RiskLevel, RiskTier
 
 
 class PolicyDecision(BaseModel):
-    """Deterministic authorization result for a planned step."""
+    """Authoritative v0.2 policy result for one normalized capability invocation."""
 
     model_config = ConfigDict(extra="forbid")
 
-    risk_level: RiskLevel
-    allowed: bool
-    requires_confirmation: bool
+    decision: PolicyDecisionValue
+    matched_rule_id: str = Field(min_length=1)
+    risk_tier: RiskTier
+    approval_mode: ApprovalMode
+    constraints_applied: list[str] = Field(default_factory=list)
+    reason_codes: list[str] = Field(default_factory=list)
+    explainability_record: dict[str, Any] = Field(default_factory=dict)
     reason: str = Field(min_length=1)
+
+    @property
+    def is_allowed(self) -> bool:
+        return self.decision == PolicyDecisionValue.ALLOW
+
+    @property
+    def requires_approval(self) -> bool:
+        return self.decision == PolicyDecisionValue.REQUIRE_APPROVAL
+
+    @property
+    def is_denied(self) -> bool:
+        return self.decision == PolicyDecisionValue.DENY
+
+    @property
+    def allowed(self) -> bool:
+        """Transitional read-only compatibility view; not part of model_dump()."""
+        return self.decision in {PolicyDecisionValue.ALLOW, PolicyDecisionValue.REQUIRE_APPROVAL}
+
+    @property
+    def requires_confirmation(self) -> bool:
+        """Transitional read-only compatibility view; v0.2 callers use requires_approval."""
+        return self.requires_approval
+
+    @property
+    def risk_level(self) -> RiskLevel:
+        """Transitional v0.1 label for old verification-suite expectations."""
+        return {
+            RiskTier.TIER_0: RiskLevel.LOW,
+            RiskTier.TIER_1: RiskLevel.MEDIUM,
+            RiskTier.TIER_2: RiskLevel.HIGH,
+            RiskTier.TIER_3: RiskLevel.FORBIDDEN,
+        }[self.risk_tier]

--- a/xfusion/execution/command_runner.py
+++ b/xfusion/execution/command_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import os
 import subprocess
 from dataclasses import dataclass
 
@@ -12,21 +13,50 @@ class CommandResult:
 
 
 class CommandRunner:
-    """Runs bounded local commands with timeout and captured output."""
+    """Runs bounded local commands with v0.2 runtime constraints."""
 
-    def run(self, command: list[str], *, timeout: float = 30.0) -> CommandResult:
-        """Run one non-interactive command."""
+    def run(
+        self,
+        command: list[str],
+        *,
+        timeout: float = 30.0,
+        max_stdout_bytes: int = 100_000,
+        max_stderr_bytes: int = 100_000,
+        cwd: str = ".",
+        env: dict[str, str] | None = None,
+    ) -> CommandResult:
+        """Run one non-interactive command from a typed adapter.
+
+        The runner never accepts shell text. It executes argument arrays with
+        shell=False, no TTY, bounded environment, bounded cwd, timeout, and
+        captured output limits.
+        """
+        if not command or any(not isinstance(part, str) or not part for part in command):
+            return CommandResult(stdout="", stderr="Invalid command argv.", exit_code=-1)
+        if command[0] in {"sh", "bash", "zsh", "python", "python3"}:
+            return CommandResult(stdout="", stderr="Prohibited interpreter adapter.", exit_code=-1)
+        bounded_env = {
+            "PATH": os.environ.get("PATH", "/usr/bin:/bin:/usr/sbin:/sbin"),
+            "LANG": os.environ.get("LANG", "C"),
+        }
+        if env:
+            for key, value in env.items():
+                if key in {"PATH", "LANG", "LC_ALL"}:
+                    bounded_env[key] = value
         try:
             result = subprocess.run(
                 command,
+                shell=False,
                 capture_output=True,
                 text=True,
                 timeout=timeout,
                 check=False,
+                cwd=cwd,
+                env=bounded_env,
             )
             return CommandResult(
-                stdout=result.stdout,
-                stderr=result.stderr,
+                stdout=result.stdout[:max_stdout_bytes],
+                stderr=result.stderr[:max_stderr_bytes],
                 exit_code=result.returncode,
             )
         except subprocess.TimeoutExpired as e:

--- a/xfusion/execution/runtime.py
+++ b/xfusion/execution/runtime.py
@@ -1,0 +1,225 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from xfusion.capabilities.schema import validate_schema_value
+from xfusion.domain.enums import FailureClass
+from xfusion.domain.models.capability import CapabilityDefinition
+from xfusion.security.redaction import redact_value
+from xfusion.tools.base import ToolOutput
+
+
+class CapabilityExecutor(Protocol):
+    def execute(self, name: str, parameters: dict[str, Any]) -> ToolOutput: ...
+
+
+class ControlledInvocation(BaseModel):
+    """Audited invocation passed to the controlled adapter runtime."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    capability: str
+    adapter_id: str
+    normalized_args: dict[str, Any]
+    runtime_constraints: dict[str, Any]
+    started_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+class AdapterOutcome(BaseModel):
+    """Normalized adapter result after runtime checks and redaction."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    invocation: ControlledInvocation
+    status: str
+    normalized_output: dict[str, Any]
+    summary: str
+    redaction_metadata: dict[str, Any]
+    ended_at: datetime = Field(default_factory=lambda: datetime.now(UTC))
+
+
+def _merge_counts(*metas: dict[str, Any]) -> dict[str, int]:
+    counts: dict[str, int] = {}
+    for meta in metas:
+        for key, count in dict(meta.get("counts", {})).items():
+            counts[key] = counts.get(key, 0) + int(count)
+    return counts
+
+
+def _safe_redact(value: Any) -> tuple[Any, dict[str, Any]]:
+    try:
+        return redact_value(value)
+    except Exception:  # noqa: BLE001 - redaction failure must fail closed without raw exposure.
+        return (
+            {
+                "failure_class": FailureClass.REDACTION_FAILURE.value,
+                "error": "redaction failed; raw value withheld",
+            },
+            {"redacted": True, "counts": {}, "redaction_failed": True},
+        )
+
+
+def _failure_outcome(
+    *,
+    invocation: ControlledInvocation,
+    status: FailureClass | str,
+    failure: dict[str, Any],
+    summary: str,
+) -> AdapterOutcome:
+    redacted_failure, failure_meta = _safe_redact(failure)
+    redacted_summary, summary_meta = _safe_redact(summary)
+    counts = _merge_counts(failure_meta, summary_meta)
+    redaction_failed = bool(failure_meta.get("redaction_failed")) or bool(
+        summary_meta.get("redaction_failed")
+    )
+    final_status = FailureClass.REDACTION_FAILURE.value if redaction_failed else str(status)
+    if redaction_failed:
+        redacted_failure = {
+            "failure_class": FailureClass.REDACTION_FAILURE.value,
+            "error": "redaction failed; raw value withheld",
+        }
+        redacted_summary = "Redaction failed; raw adapter data was withheld."
+    return AdapterOutcome(
+        invocation=invocation,
+        status=final_status,
+        normalized_output=redacted_failure,
+        summary=str(redacted_summary),
+        redaction_metadata={
+            "redacted": bool(counts) or redaction_failed,
+            "counts": counts,
+            "redaction_failed": redaction_failed,
+        },
+    )
+
+
+class ControlledAdapterRuntime:
+    """v0.2 runtime wrapper around registered typed capability adapters."""
+
+    def __init__(self, executor: CapabilityExecutor) -> None:
+        self.executor = executor
+
+    def execute(
+        self,
+        *,
+        capability: CapabilityDefinition,
+        normalized_args: dict[str, Any],
+    ) -> AdapterOutcome:
+        invocation = ControlledInvocation(
+            capability=capability.name,
+            adapter_id=capability.adapter_id,
+            normalized_args=normalized_args,
+            runtime_constraints=capability.runtime_constraints.model_dump(),
+        )
+        failure = self._validate_runtime_constraints(capability=capability, args=normalized_args)
+        if failure:
+            return AdapterOutcome(
+                invocation=invocation,
+                status="runtime_rejected",
+                normalized_output={"error": failure},
+                summary=f"Runtime rejected capability '{capability.name}': {failure}",
+                redaction_metadata={"redacted": False, "counts": {}},
+            )
+
+        try:
+            output = self.executor.execute(capability.name, normalized_args)
+        except TimeoutError as exc:
+            raw_failure = {
+                "failure_class": FailureClass.RUNTIME_TIMEOUT.value,
+                "error": str(exc),
+                "exception_type": exc.__class__.__name__,
+            }
+            return _failure_outcome(
+                invocation=invocation,
+                status=FailureClass.RUNTIME_TIMEOUT,
+                failure=raw_failure,
+                summary=f"Runtime timed out for capability '{capability.name}': {exc}",
+            )
+        except Exception as exc:  # noqa: BLE001 - adapter boundary must normalize all failures.
+            raw_failure = {
+                "failure_class": FailureClass.ADAPTER_FAILURE.value,
+                "error": str(exc),
+                "exception_type": exc.__class__.__name__,
+            }
+            return _failure_outcome(
+                invocation=invocation,
+                status=FailureClass.ADAPTER_FAILURE,
+                failure=raw_failure,
+                summary=f"Adapter failed for capability '{capability.name}': {exc}",
+            )
+
+        try:
+            output_data = output.data
+            output_summary = output.summary
+            schema_result = validate_schema_value(output_data, capability.output_schema)
+            if not schema_result.valid:
+                failure = {
+                    "failure_class": FailureClass.OUTPUT_SCHEMA_VALIDATION_FAILURE.value,
+                    "capability": capability.name,
+                    "adapter_id": capability.adapter_id,
+                    "validation_errors": schema_result.errors,
+                }
+                return _failure_outcome(
+                    invocation=invocation,
+                    status="output_schema_validation_failed",
+                    failure=failure,
+                    summary=(
+                        "Adapter output failed schema validation for capability "
+                        f"'{capability.name}'."
+                    ),
+                )
+
+            redacted_data, redaction_metadata = _safe_redact(output_data)
+            redacted_summary, summary_meta = _safe_redact(output_summary)
+            redaction_failed = bool(redaction_metadata.get("redaction_failed")) or bool(
+                summary_meta.get("redaction_failed")
+            )
+            if redaction_failed:
+                return _failure_outcome(
+                    invocation=invocation,
+                    status=FailureClass.REDACTION_FAILURE,
+                    failure={
+                        "failure_class": FailureClass.REDACTION_FAILURE.value,
+                        "error": "redaction failed; raw adapter data withheld",
+                    },
+                    summary="Redaction failed; raw adapter data was withheld.",
+                )
+            counts = _merge_counts(redaction_metadata, summary_meta)
+            return AdapterOutcome(
+                invocation=invocation,
+                status="failed" if "error" in redacted_data else "succeeded",
+                normalized_output=redacted_data,
+                summary=str(redacted_summary),
+                redaction_metadata={"redacted": bool(counts), "counts": counts},
+            )
+        except Exception as exc:  # noqa: BLE001 - output handling is inside the trust boundary.
+            return _failure_outcome(
+                invocation=invocation,
+                status=FailureClass.INTERNAL_SYSTEM_FAILURE,
+                failure={
+                    "failure_class": FailureClass.INTERNAL_SYSTEM_FAILURE.value,
+                    "error": str(exc),
+                    "exception_type": exc.__class__.__name__,
+                },
+                summary=f"Internal system failure while handling capability '{capability.name}'.",
+            )
+
+    def _validate_runtime_constraints(
+        self, *, capability: CapabilityDefinition, args: dict[str, Any]
+    ) -> str | None:
+        constraints = capability.runtime_constraints
+        if constraints.interactive_tty:
+            return "interactive_tty_forbidden"
+        if constraints.network_access != "denied":
+            return "network_must_be_explicitly_policy_allowed"
+        if constraints.timeout_sec <= 0 or constraints.timeout_sec > 120:
+            return "timeout_out_of_bounds"
+        if constraints.max_stdout_bytes > 1_000_000 or constraints.max_stderr_bytes > 1_000_000:
+            return "byte_limit_out_of_bounds"
+        if "command" in args:
+            return "free_form_command_arg_forbidden"
+        if capability.adapter_id in {"run_command", "shell", "bash", "sh"}:
+            return "prohibited_adapter"
+        return None

--- a/xfusion/execution/runtime.py
+++ b/xfusion/execution/runtime.py
@@ -29,7 +29,7 @@ class ControlledInvocation(BaseModel):
 
 
 class AdapterOutcome(BaseModel):
-    """Normalized adapter result after runtime checks and redaction."""
+    """Authoritative adapter result after schema validation and redaction."""
 
     model_config = ConfigDict(extra="forbid")
 
@@ -96,7 +96,12 @@ def _failure_outcome(
 
 
 class ControlledAdapterRuntime:
-    """v0.2 runtime wrapper around registered typed capability adapters."""
+    """Trust-boundary wrapper around registered typed capability adapters.
+
+    The executor may call OS-facing adapters, but this runtime owns the
+    deterministic boundary around runtime constraints, output schema validation,
+    redaction, and normalized failure records.
+    """
 
     def __init__(self, executor: CapabilityExecutor) -> None:
         self.executor = executor

--- a/xfusion/graph/auditing.py
+++ b/xfusion/graph/auditing.py
@@ -6,6 +6,7 @@ from xfusion.audit.jsonl_sink import JsonlAuditSink
 from xfusion.audit.logger import AuditLogger
 from xfusion.domain.models.execution_plan import PlanStep
 from xfusion.graph.state import AgentGraphState
+from xfusion.security.redaction import redact_value
 
 
 def log_graph_event(
@@ -27,11 +28,15 @@ def log_graph_event(
     else:
         action = dict[str, object](
             {
-                "tool": step.tool,
-                "parameters": step.parameters,
+                "capability": step.capability,
+                "normalized_args": step.normalized_args or step.args,
+                "argument_provenance": step.argument_provenance,
+                "resolved_references": step.resolved_references,
                 "output": state.step_outputs.get(step.step_id, {}),
             }
         )
+        if step.failure_details:
+            action.update(step.failure_details)
     after_state: dict[str, object] = {
         "plan_status": state.plan.status,
         "step_status": step.status,
@@ -40,17 +45,59 @@ def log_graph_event(
         state.verification_result.model_dump() if state.verification_result else {}
     )
 
+    original_user_request, request_redaction = redact_value(state.user_input)
+    interpreted_intent, intent_redaction = redact_value(state.plan.goal)
+    role_proposals, role_redaction = redact_value(
+        {key: contract.model_dump() for key, contract in state.role_contracts.items()}
+    )
+    plan_draft, plan_redaction = redact_value(state.plan.model_dump(mode="json"))
+    normalized_args, args_redaction = redact_value(step.normalized_args or step.args)
+    summary_value, summary_redaction = redact_value(summary)
+    redacted_action, action_redaction = redact_value(action)
+    redacted_verification, verification_redaction = redact_value(verification)
+    normalized_output = state.step_outputs.get(step.step_id, {})
+    redacted_output, output_redaction = redact_value(normalized_output)
+
     record = {
         "timestamp": datetime.now().isoformat(),
         "plan_id": state.plan.plan_id,
+        "original_user_request": original_user_request,
+        "interpreted_intent": interpreted_intent,
+        "role_proposals": role_proposals,
+        "plan_draft": plan_draft,
+        "validation_result": state.validation_result.model_dump(mode="json")
+        if state.validation_result
+        else None,
         "step_id": step.step_id,
+        "capability": step.capability,
+        "normalized_args": normalized_args,
+        "argument_provenance": step.argument_provenance,
+        "resolved_references": step.resolved_references,
+        "matched_policy_rule": step.policy_rule_id,
+        "approval_mode": step.approval_mode,
+        "approval_id": step.approval_id,
+        "action_fingerprint": step.action_fingerprint,
+        "adapter_id": step.adapter_id,
         "interaction_state": state.plan.interaction_state,
         "before_state": before_state,
-        "action_taken": action,
+        "action_taken": redacted_action,
         "after_state": after_state,
-        "verification_result": verification,
+        "verification_result": redacted_verification,
+        "normalized_output": redacted_output,
+        "redaction_metadata": {
+            "action": action_redaction,
+            "verification": verification_redaction,
+            "output": output_redaction,
+            "original_user_request": request_redaction,
+            "interpreted_intent": intent_redaction,
+            "role_proposals": role_redaction,
+            "plan_draft": plan_redaction,
+            "normalized_args": args_redaction,
+            "summary": summary_redaction,
+            "step": step.redaction_metadata,
+        },
         "status": status,
-        "summary": summary,
+        "summary": summary_value,
     }
     state.audit_records.append(record)
 
@@ -60,9 +107,9 @@ def log_graph_event(
             step_id=step.step_id,
             interaction_state=str(state.plan.interaction_state),
             before_state=before_state,
-            action_taken=action,
+            action_taken=redacted_action,
             after_state=after_state,
-            verification_result=verification,
+            verification_result=redacted_verification,
             status=status,
-            summary=summary,
+            summary=str(summary_value),
         )

--- a/xfusion/graph/nodes/confirm.py
+++ b/xfusion/graph/nodes/confirm.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
-from xfusion.domain.enums import InteractionState
+from datetime import UTC, datetime
+
+from xfusion.domain.enums import FailureClass, InteractionState
 from xfusion.graph.auditing import log_graph_event
 from xfusion.graph.state import AgentGraphState
 
@@ -16,22 +18,52 @@ def confirm_node(state: AgentGraphState) -> AgentGraphState:
 
     expected = (step.confirmation_phrase or "").strip()
     actual = state.user_input.strip()
+    approval = state.approval_records.get(state.pending_approval_id or step.approval_id or "")
 
-    if expected and actual == expected:
+    if expected and approval and actual == expected and not approval.is_expired():
+        approval.approved_at = datetime.now(UTC)
         state.plan.interaction_state = InteractionState.EXECUTING
         step.requires_confirmation = False
         state.response = "Confirmation received. Proceeding..."
-        log_graph_event(state, step=step, status="confirmed", summary=state.response)
+        log_graph_event(
+            state,
+            step=step,
+            status="approval_granted",
+            summary=state.response,
+            action_taken={"approval_response": approval.model_dump(mode="json")},
+        )
     else:
         state.plan.interaction_state = InteractionState.ABORTED
         state.plan.status = "aborted"
-        state.response = (
-            f"Action aborted: Input did not match required confirmation phrase '{expected}'."
+        reason = "approval_expired" if approval and approval.is_expired() else "phrase_mismatch"
+        step.failure_class = (
+            FailureClass.APPROVAL_EXPIRED.value
+            if reason == "approval_expired"
+            else FailureClass.APPROVAL_DENIED.value
         )
-        log_graph_event(state, step=step, status="aborted", summary=state.response)
+        step.failure_details = {
+            "failure_class": step.failure_class,
+            "approval_id": approval.approval_id if approval else None,
+            "reason": reason,
+        }
+        state.response = f"Action aborted: approval failed ({reason})."
+        if approval:
+            approval.invalidated_at = datetime.now(UTC)
+            approval.invalidation_reason = reason
+        log_graph_event(
+            state,
+            step=step,
+            status="approval_denied",
+            summary=state.response,
+            action_taken={
+                "approval_id": approval.approval_id if approval else None,
+                "reason": reason,
+            },
+        )
 
     # Requirements: Confirmation must be cleared after one use.
     state.pending_confirmation_phrase = None
+    state.pending_approval_id = None
     step.confirmation_phrase = None
 
     return state

--- a/xfusion/graph/nodes/execute.py
+++ b/xfusion/graph/nodes/execute.py
@@ -1,41 +1,15 @@
 from __future__ import annotations
 
-from typing import Any
-
+from xfusion.capabilities.registry import build_default_capability_registry
 from xfusion.domain.enums import InteractionState, StepStatus
+from xfusion.execution.runtime import ControlledAdapterRuntime
 from xfusion.graph.state import AgentGraphState
-
-
-def resolve_parameter(param: Any, step_outputs: dict[str, dict[str, Any]]) -> Any:
-    """Resolve reference parameter like {'ref': 'step_id.key[index]' or 'step_id.key'}."""
-    if not isinstance(param, dict) or "ref" not in param:
-        return param
-
-    ref = str(param["ref"])
-    try:
-        # Format: step_id.key or step_id.key[index]
-        parts = ref.split(".", 1)
-        if len(parts) != 2:
-            raise ValueError(f"Invalid reference format: {ref}")
-
-        step_id, attr = parts
-        if step_id not in step_outputs:
-            raise ValueError(f"Referenced step '{step_id}' output not found.")
-
-        output_data = step_outputs[step_id]
-
-        # Check for index access like pids[0]
-        if "[" in attr and attr.endswith("]"):
-            key, idx_str = attr.rstrip("]").split("[", 1)
-            idx = int(idx_str)
-            val = output_data[key]
-            if not isinstance(val, list):
-                raise ValueError(f"Attribute '{key}' is not a list.")
-            return val[idx]
-        else:
-            return output_data[attr]
-    except (ValueError, KeyError, IndexError) as e:
-        raise ValueError(f"Failed to resolve reference '{ref}': {e}") from e
+from xfusion.planning.reference_resolver import resolve_args
+from xfusion.policy.approval import (
+    build_argument_provenance,
+    build_referenced_output_fingerprints,
+    validate_approval_for_invocation,
+)
 
 
 def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
@@ -55,32 +29,93 @@ def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
         return state
 
     step.status = StepStatus.RUNNING
+    step.failure_class = None
+    step.failure_details = {}
+    step.authorized_output_accepted = False
+    state.step_outputs.pop(step.step_id, None)
+    state.authorized_step_outputs.pop(step.step_id, None)
+    state.last_tool_output = None
+    state.verification_result = None
 
-    # Resolve parameters
-    resolved_params = {}
+    capability = build_default_capability_registry().require(str(step.capability))
+
     try:
-        for k, v in step.parameters.items():
-            resolved_params[k] = resolve_parameter(v, state.step_outputs)
+        resolved_params = resolve_args(
+            step.args,
+            plan=state.plan,
+            authorized_outputs=state.authorized_step_outputs,
+        )
     except ValueError as e:
         step.status = StepStatus.FAILED
+        step.failure_class = "reference_resolution_failed"
+        step.failure_details = {
+            "failure_class": "reference_resolution_failed",
+            "capability": step.capability,
+            "args": step.args,
+            "error": str(e),
+        }
         state.response = f"Parameter resolution failed: {e}"
         return state
 
-    # Execute with resolved parameters
-    output = registry.execute(step.tool, resolved_params)
+    if step.approval_id:
+        approval = state.approval_records.get(step.approval_id)
+        if approval is None:
+            step.status = StepStatus.FAILED
+            step.failure_class = "approval_missing"
+            step.failure_details = {
+                "failure_class": "approval_missing",
+                "approval_id": step.approval_id,
+                "capability": step.capability,
+            }
+            state.response = "Approval required but no approval record exists."
+            return state
+        is_valid, reason = validate_approval_for_invocation(
+            approval=approval,
+            capability=capability,
+            normalized_args=resolved_params,
+            target_context=state.plan.target_context,
+            approval_mode=approval.approval_mode,
+            risk_tier=approval.risk_tier,
+            argument_provenance=build_argument_provenance(step.args),
+            referenced_output_fingerprints=build_referenced_output_fingerprints(
+                step.args, state.authorized_step_outputs
+            ),
+        )
+        if not is_valid:
+            step.status = StepStatus.FAILED
+            step.failure_class = (
+                "approval_invalidated"
+                if reason in {"action_fingerprint_mismatch", "material_change"}
+                else reason
+            )
+            step.failure_details = {
+                "failure_class": step.failure_class,
+                "reason": reason,
+                "approval_id": approval.approval_id,
+                "capability": step.capability,
+                "normalized_args": resolved_params,
+            }
+            state.response = f"Approval invalidated before execution: {reason}"
+            return state
 
-    # Store output in state for real verification AND for downstream steps
-    state.last_tool_output = output.data
-    state.step_outputs[step.step_id] = output.data
-    state.verification_result = None  # Clear previous
+    outcome = ControlledAdapterRuntime(registry).execute(
+        capability=capability,
+        normalized_args=resolved_params,
+    )
 
-    # Tool failure still sets step status to FAILED
-    if "error" in output.data:
+    step.normalized_args = resolved_params
+    step.adapter_id = capability.adapter_id
+    step.redaction_metadata = outcome.redaction_metadata
+
+    if outcome.status != "succeeded" or "error" in outcome.normalized_output:
         step.status = StepStatus.FAILED
-        # We don't set InteractionState.FAILED here, update_node will handle it
-        state.response = f"Step failed: {output.summary}"
+        step.failure_class = outcome.status
+        step.failure_details = outcome.normalized_output
+        state.last_tool_output = None
+        state.response = f"Step failed: {outcome.summary}"
     else:
-        # We do NOT set SUCCESS here. Verification node must do that.
-        state.response = output.summary
+        state.last_tool_output = outcome.normalized_output
+        state.step_outputs[step.step_id] = outcome.normalized_output
+        state.response = outcome.summary
 
     return state

--- a/xfusion/graph/nodes/parse.py
+++ b/xfusion/graph/nodes/parse.py
@@ -5,8 +5,7 @@ from xfusion.graph.state import AgentGraphState
 
 def parse_node(state: AgentGraphState) -> AgentGraphState:
     """Normalize language input and produce a parsed intent candidate."""
-    # In v0.1, we use a simple parser or LLM to detect the intent.
-    # For now, let's just assume we can detect the language.
+    # Keep request interpretation non-authoritative; validation and policy own safety.
     if any("\u4e00" <= c <= "\u9fff" for c in state.user_input):
         state.language = "zh"
     else:

--- a/xfusion/graph/nodes/plan.py
+++ b/xfusion/graph/nodes/plan.py
@@ -9,11 +9,11 @@ from xfusion.graph.state import AgentGraphState
 
 
 def plan_node(state: AgentGraphState) -> AgentGraphState:
-    """Create or revise ExecutionPlan."""
+    """Create a deterministic v0.2 ExecutionPlan draft for known demo workflows."""
     if state.plan:
         return state
 
-    # Deterministic planning for common v0.1 scenarios
+    # Deterministic planning for common bounded scenarios; static validation is authoritative.
     user_input = state.user_input.lower()
 
     steps = []

--- a/xfusion/graph/nodes/plan.py
+++ b/xfusion/graph/nodes/plan.py
@@ -112,6 +112,7 @@ def plan_node(state: AgentGraphState) -> AgentGraphState:
                     success_condition="Cleanup reports deleted candidates or safe no-op.",
                     failure_condition="Cleanup execution fails.",
                     fallback_action="Abort and preserve remaining files.",
+                    verification_step_ids=["verify_disk_after_cleanup"],
                 ),
                 PlanStep(
                     step_id="verify_disk_after_cleanup",
@@ -240,13 +241,14 @@ def plan_node(state: AgentGraphState) -> AgentGraphState:
                 step_id="kill_process",
                 intent=f"Stop the process found on port {port}.",
                 tool="process.kill",
-                parameters={"pid": {"ref": "find_process.pids[0]"}, "port": port},
+                parameters={"pid": "$steps.find_process.outputs.pids[0]", "port": port},
                 dependencies=["find_process"],
                 expected_output=f"Process on port {port} is stopped.",
                 verification_method="command_exit_status_plus_state",
                 success_condition=f"Process on port {port} is killed.",
                 failure_condition=f"Process on port {port} is still running.",
                 fallback_action="stop",
+                verification_step_ids=["verify_port_free"],
             )
         )
 
@@ -340,11 +342,24 @@ def plan_node(state: AgentGraphState) -> AgentGraphState:
         state.response = clarification
         return state
 
+    mutating_tools = {
+        "process.kill",
+        "user.create",
+        "user.delete",
+        "cleanup.safe_disk_cleanup",
+    }
+    verification_strategy = (
+        "Verify mutating workflow outcomes with planned post-action checks."
+        if any(step.tool in mutating_tools for step in steps)
+        else None
+    )
+
     state.plan = ExecutionPlan(
         plan_id=str(uuid.uuid4()),
         goal=goal,
         language=state.language,
         interaction_state=InteractionState.EXECUTING,
         steps=steps,
+        verification_strategy=verification_strategy,
     )
     return state

--- a/xfusion/graph/nodes/policy.py
+++ b/xfusion/graph/nodes/policy.py
@@ -1,8 +1,14 @@
 from __future__ import annotations
 
-from xfusion.domain.enums import InteractionState
+from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.domain.enums import InteractionState, PolicyDecisionValue, StepStatus
 from xfusion.graph.auditing import log_graph_event
 from xfusion.graph.state import AgentGraphState
+from xfusion.planning.reference_resolver import resolve_args
+from xfusion.policy.approval import (
+    build_argument_provenance,
+    create_approval_record,
+)
 from xfusion.policy.rules import evaluate_policy
 
 
@@ -17,49 +23,132 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
 
     state.current_step_id = step.step_id
 
+    registry = build_default_capability_registry()
+    capability = registry.require(str(step.capability))
+
+    try:
+        resolved_args = resolve_args(
+            step.args,
+            plan=state.plan,
+            authorized_outputs=state.authorized_step_outputs,
+        )
+    except ValueError as e:
+        step.status = StepStatus.FAILED
+        step.failure_class = "reference_resolution_failed"
+        step.failure_details = {
+            "failure_class": "reference_resolution_failed",
+            "capability": step.capability,
+            "args": step.args,
+            "error": str(e),
+        }
+        state.plan.interaction_state = InteractionState.FAILED
+        state.plan.status = "failed"
+        state.response = f"Reference resolution failed: {e}"
+        log_graph_event(
+            state,
+            step=step,
+            status="reference_resolution_failed",
+            summary=state.response,
+            action_taken={"capability": step.capability, "args": step.args, "error": str(e)},
+        )
+        return state
+
+    provenance = build_argument_provenance(step.args)
+    step.normalized_args = resolved_args
+    step.argument_provenance = provenance
+    step.adapter_id = capability.adapter_id
+
     decision = evaluate_policy(
-        tool=step.tool, parameters=step.parameters, environment=state.environment
+        capability_name=str(step.capability),
+        resolved_args=resolved_args,
+        argument_provenance=provenance,
+        environment=state.environment,
+        actor_type="assistant",
+        host_class="production",
+        target_scope="explicit",
+        request_intent=state.plan.intent_class,
+        prior_approval_state={
+            approval_id: approval.model_dump(mode="json")
+            for approval_id, approval in state.approval_records.items()
+        },
     )
 
     state.policy_decision = decision
 
-    # Update step with policy details
     step.risk_level = decision.risk_level
-    step.requires_confirmation = decision.requires_confirmation
+    step.requires_confirmation = decision.requires_approval
+    step.policy_rule_id = decision.matched_rule_id
+    step.approval_mode = decision.approval_mode
 
-    if not decision.allowed:
+    if decision.decision == PolicyDecisionValue.DENY:
+        step.status = StepStatus.REFUSED
+        step.failure_class = (
+            "scope_violation"
+            if {"scope_violation", "scope_not_explicit"} & set(decision.reason_codes)
+            else "policy_denial"
+        )
+        step.failure_details = {
+            "failure_class": step.failure_class,
+            "policy_decision": decision.model_dump(),
+        }
         state.plan.interaction_state = InteractionState.REFUSED
         state.plan.status = "refused"
         state.response = f"I cannot execute this step: {decision.reason}"
         log_graph_event(
             state,
             step=step,
-            status="refused",
+            status=step.failure_class,
             summary=state.response,
             action_taken={
-                "tool": step.tool,
-                "parameters": step.parameters,
+                "capability": step.capability,
+                "normalized_args": resolved_args,
+                "argument_provenance": provenance,
+                "failure_class": step.failure_class,
                 "policy_decision": decision.model_dump(),
             },
         )
-    elif decision.requires_confirmation:
+    elif decision.decision == PolicyDecisionValue.REQUIRE_APPROVAL:
+        existing = state.approval_records.get(step.approval_id or "")
+        if existing and existing.is_approved:
+            state.response = "Existing approval record found; validating before execution."
+            return state
+
+        approval = create_approval_record(
+            plan=state.plan,
+            step=step,
+            capability=capability,
+            normalized_args=resolved_args,
+            target_context=state.plan.target_context,
+            approval_mode=decision.approval_mode,
+            risk_tier=decision.risk_tier,
+            authorized_outputs=state.authorized_step_outputs,
+        )
+        state.approval_records[approval.approval_id] = approval
+        state.pending_approval_id = approval.approval_id
+        step.approval_id = approval.approval_id
+        step.action_fingerprint = approval.action_fingerprint
+
         state.plan.interaction_state = InteractionState.AWAITING_CONFIRMATION
         state.plan.status = "awaiting_confirmation"
-        # Requirements: Exact typed confirmation phrase is required.
-        # Format: "I understand the risks of <intent>"
-        phrase = f"I understand the risks of {step.intent}"
+        phrase = approval.typed_confirmation_phrase
         step.confirmation_phrase = phrase
         state.pending_confirmation_phrase = phrase
-        state.response = f"This action requires confirmation. Please type: '{phrase}'"
+        state.response = (
+            "This action requires approval. "
+            f"Preview: {approval.preview.action_summary}; impacted target: "
+            f"{approval.preview.impacted_target}. Please type: '{phrase}'"
+        )
         log_graph_event(
             state,
             step=step,
-            status="awaiting_confirmation",
+            status="approval_requested",
             summary=state.response,
             action_taken={
-                "tool": step.tool,
-                "parameters": step.parameters,
+                "capability": step.capability,
+                "normalized_args": resolved_args,
+                "argument_provenance": provenance,
                 "policy_decision": decision.model_dump(),
+                "approval_request": approval.model_dump(mode="json"),
             },
         )
 

--- a/xfusion/graph/nodes/update.py
+++ b/xfusion/graph/nodes/update.py
@@ -10,7 +10,20 @@ def update_node(state: AgentGraphState) -> AgentGraphState:
     if not state.plan:
         return state
 
-    # Create audit record
+    dependency_abort = False
+    if state.plan.interaction_state == InteractionState.EXECUTING and (
+        any(s.status == StepStatus.FAILED for s in state.plan.steps)
+        or state.plan.has_unexecutable_pending_steps()
+    ):
+        state.plan.interaction_state = InteractionState.FAILED
+        state.plan.status = "failed"
+        dependency_abort = state.plan.has_unexecutable_pending_steps()
+        if dependency_abort:
+            state.response = (
+                f"{state.response}\nPlan execution aborted: one or more dependencies failed."
+            )
+
+    # Create audit record from authoritative post-transition state.
     if state.current_step_id:
         step = next(
             (
@@ -21,27 +34,24 @@ def update_node(state: AgentGraphState) -> AgentGraphState:
             None,
         )
         if step:
+            if step.status == StepStatus.SUCCESS:
+                step.authorized_output_accepted = True
+                state.authorized_step_outputs[step.step_id] = state.step_outputs.get(
+                    step.step_id, {}
+                )
+            audit_status = step.failure_class or str(step.status)
             log_graph_event(
                 state,
                 step=step,
-                status=str(step.status),
+                status=audit_status,
                 summary=state.response,
             )
 
-    # Check if plan is complete or blocked
-    if state.plan.interaction_state == InteractionState.EXECUTING:
-        if all(s.status == StepStatus.SUCCESS for s in state.plan.steps):
-            state.plan.interaction_state = InteractionState.COMPLETED
-            state.plan.status = "completed"
-        elif (
-            any(s.status == StepStatus.FAILED for s in state.plan.steps)
-            or state.plan.has_unexecutable_pending_steps()
-        ):
-            state.plan.interaction_state = InteractionState.FAILED
-            state.plan.status = "failed"
-            if state.plan.has_unexecutable_pending_steps():
-                state.response = (
-                    f"{state.response}\nPlan execution aborted: one or more dependencies failed."
-                )
+    # Check if plan is complete.
+    if state.plan.interaction_state == InteractionState.EXECUTING and all(
+        s.status == StepStatus.SUCCESS for s in state.plan.steps
+    ):
+        state.plan.interaction_state = InteractionState.COMPLETED
+        state.plan.status = "completed"
 
     return state

--- a/xfusion/graph/nodes/validate.py
+++ b/xfusion/graph/nodes/validate.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.domain.enums import InteractionState
+from xfusion.graph.auditing import log_graph_event
+from xfusion.graph.state import AgentGraphState
+from xfusion.planning.validator import validate_plan
+
+
+def validate_node(state: AgentGraphState) -> AgentGraphState:
+    """Run mandatory v0.2 static validation before policy or execution."""
+    if not state.plan:
+        return state
+
+    if state.plan.interaction_state == InteractionState.AWAITING_DISAMBIGUATION:
+        return state
+
+    result = validate_plan(state.plan, build_default_capability_registry())
+    state.validation_result = result
+
+    if result.valid:
+        return state
+
+    state.plan.interaction_state = InteractionState.FAILED
+    state.plan.status = "failed"
+    first_error = result.errors[0]
+    state.response = f"Plan validation failed: {first_error.message}"
+
+    step = state.plan.next_executable_step()
+    if step:
+        log_graph_event(
+            state,
+            step=step,
+            status="validation_failed",
+            summary=state.response,
+            action_taken={
+                "validation_result": result.model_dump(),
+                "capability": step.capability,
+                "args": step.args,
+            },
+        )
+
+    return state

--- a/xfusion/graph/nodes/verify.py
+++ b/xfusion/graph/nodes/verify.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from xfusion.domain.enums import StepStatus
+from xfusion.domain.enums import FailureClass, StepStatus
 from xfusion.domain.models.verification import VerificationResult
 from xfusion.graph.state import AgentGraphState
 
@@ -141,7 +141,7 @@ def verify_node(state: AgentGraphState) -> AgentGraphState:
     success, summary = _dispatch_verification(
         step.verification_method,
         step.success_condition,
-        step.parameters,
+        step.normalized_args or step.args,
         tool_output,
     )
 
@@ -157,6 +157,13 @@ def verify_node(state: AgentGraphState) -> AgentGraphState:
         step.status = StepStatus.SUCCESS
     else:
         step.status = StepStatus.FAILED
+        step.failure_class = FailureClass.VERIFICATION_FAILURE.value
+        step.failure_details = {
+            "failure_class": FailureClass.VERIFICATION_FAILURE.value,
+            "method": step.verification_method,
+            "summary": summary,
+            "details": tool_output,
+        }
         state.response = f"Verification failed: {summary}"
 
     return state

--- a/xfusion/graph/response.py
+++ b/xfusion/graph/response.py
@@ -1,27 +1,41 @@
 from __future__ import annotations
 
+from typing import Any, cast
+
 from xfusion.domain.enums import InteractionState
 from xfusion.graph.state import AgentGraphState
 
 
 def format_agent_response(state: AgentGraphState) -> str:
-    """Build the judge-facing response contract from deterministic state."""
+    """Build the judge-facing response from authoritative audited state."""
     if not state.plan:
         return state.response
 
     plan = state.plan
     env = state.environment
-    plan_tools = ", ".join(step.tool for step in plan.steps) if plan.steps else "none"
-    risk = state.policy_decision.risk_level if state.policy_decision else "none"
-    risk_reason = (
-        state.policy_decision.reason if state.policy_decision else "No policy action needed."
+    source_record = _latest_authoritative_record(state)
+    source_plan = source_record.get("plan_draft") if source_record else None
+    source_plan_dict = cast(dict[str, Any], source_plan) if isinstance(source_plan, dict) else {}
+    source_steps = source_plan_dict.get("steps", [])
+    plan_tools = _plan_tools_from_audit(source_steps) or (
+        ", ".join(str(step.capability) for step in plan.steps) if plan.steps else "none"
+    )
+    policy_record = _policy_record_from_audit(source_record)
+    risk = policy_record.get("risk_tier", "none")
+    risk_reason = policy_record.get("reason", "No policy action needed.")
+    verification_record = cast(
+        dict[str, Any], source_record.get("verification_result", {}) if source_record else {}
     )
     verification = (
-        state.verification_result.summary
-        if state.verification_result
+        verification_record.get("summary")
+        if isinstance(verification_record, dict) and verification_record.get("summary")
         else "Not executed for this state."
     )
-    action = state.response or "No action executed."
+    action = (
+        str(source_record.get("summary"))
+        if source_record and source_record.get("summary")
+        else state.response or "No action executed."
+    )
 
     if plan.interaction_state == InteractionState.AWAITING_CONFIRMATION:
         action = f"Confirmation required: type '{state.pending_confirmation_phrase}'."
@@ -29,10 +43,16 @@ def format_agent_response(state: AgentGraphState) -> str:
         action = plan.clarification_question or state.response
 
     next_step = _next_recommendation(state)
+    audit_status = source_record["status"] if source_record else "not_recorded"
+    intent = (
+        str(source_record.get("interpreted_intent"))
+        if source_record and source_record.get("interpreted_intent")
+        else plan.goal
+    )
 
-    return "\n".join(
+    response = "\n".join(
         [
-            f"Intent: {plan.goal}",
+            f"Intent: {intent}",
             (
                 "Environment: "
                 f"{env.distro_family} {env.distro_version}; "
@@ -44,10 +64,57 @@ def format_agent_response(state: AgentGraphState) -> str:
             f"Risk: {risk} - {risk_reason}",
             f"Action: {action}",
             f"Verification: {verification}",
+            f"Audit: explanation derived from authoritative audit status={audit_status}",
             f"State: {plan.interaction_state}; status={plan.status}",
             f"Next: {next_step}",
         ]
     )
+    state.audit_records.append(
+        {
+            "timestamp": "final",
+            "plan_id": plan.plan_id,
+            "event": "final_explanation_snapshot",
+            "response": response,
+            "source_audit_status": audit_status,
+            "source_audit_record": source_record,
+        }
+    )
+    return response
+
+
+def _latest_authoritative_record(state: AgentGraphState) -> dict[str, object] | None:
+    for record in reversed(state.audit_records):
+        if not isinstance(record, dict):
+            continue
+        if record.get("event") == "final_explanation_snapshot":
+            continue
+        if record.get("status"):
+            return record
+    return None
+
+
+def _plan_tools_from_audit(source_steps: object) -> str:
+    if not isinstance(source_steps, list):
+        return ""
+    capabilities = [
+        str(cast(dict[str, Any], step).get("capability"))
+        for step in source_steps
+        if isinstance(step, dict) and cast(dict[str, Any], step).get("capability")
+    ]
+    return ", ".join(capabilities)
+
+
+def _policy_record_from_audit(source_record: dict[str, object] | None) -> dict[str, object]:
+    if not source_record:
+        return {}
+    action = source_record.get("action_taken")
+    if not isinstance(action, dict):
+        return {}
+    action_dict = cast(dict[str, Any], action)
+    policy_decision = action_dict.get("policy_decision")
+    if isinstance(policy_decision, dict):
+        return policy_decision
+    return {}
 
 
 def _next_recommendation(state: AgentGraphState) -> str:

--- a/xfusion/graph/state.py
+++ b/xfusion/graph/state.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 from pydantic import BaseModel, ConfigDict, Field
 
+from xfusion.domain.models.approval import ApprovalRecord
 from xfusion.domain.models.environment import EnvironmentState
 from xfusion.domain.models.execution_plan import ExecutionPlan
 from xfusion.domain.models.policy import PolicyDecision
 from xfusion.domain.models.verification import VerificationResult
+from xfusion.planning.validator import PlanValidationResult
+from xfusion.roles.contracts import RoleContract, build_default_role_contracts
 
 
 class AgentGraphState(BaseModel):
@@ -18,11 +21,20 @@ class AgentGraphState(BaseModel):
     environment: EnvironmentState
     plan: ExecutionPlan | None = None
     current_step_id: str | None = None
+    validation_result: PlanValidationResult | None = None
     policy_decision: PolicyDecision | None = None
     verification_result: VerificationResult | None = None
     last_tool_output: dict[str, object] | None = None
     step_outputs: dict[str, dict[str, object]] = Field(default_factory=dict)
+    authorized_step_outputs: dict[str, dict[str, object]] = Field(default_factory=dict)
+    approval_records: dict[str, ApprovalRecord] = Field(default_factory=dict)
+    pending_approval_id: str | None = None
     pending_confirmation_phrase: str | None = None
+    role_contracts: dict[str, RoleContract] = Field(
+        default_factory=lambda: {
+            role.value: contract for role, contract in build_default_role_contracts().items()
+        }
+    )
     response: str = ""
     audit_records: list[dict[str, object]] = Field(default_factory=list)
     audit_log_path: str | None = None

--- a/xfusion/graph/wiring.py
+++ b/xfusion/graph/wiring.py
@@ -12,6 +12,7 @@ from xfusion.graph.nodes.plan import plan_node
 from xfusion.graph.nodes.policy import policy_node
 from xfusion.graph.nodes.respond import respond_node
 from xfusion.graph.nodes.update import update_node
+from xfusion.graph.nodes.validate import validate_node
 from xfusion.graph.nodes.verify import verify_node
 from xfusion.graph.state import AgentGraphState
 
@@ -43,6 +44,17 @@ def route_after_policy(state: AgentGraphState) -> str:
     return "execute"
 
 
+def route_after_validate(state: AgentGraphState) -> str:
+    """Route after mandatory static validation."""
+    if not state.plan:
+        return "respond"
+
+    if state.plan.interaction_state in {"failed", "refused", "aborted"}:
+        return "respond"
+
+    return "policy"
+
+
 def route_after_update(state: AgentGraphState) -> str:
     """Route after state update to decide if we need more steps."""
     if not state.plan:
@@ -51,7 +63,7 @@ def route_after_update(state: AgentGraphState) -> str:
     if state.plan.interaction_state in {"completed", "failed", "aborted", "refused"}:
         return "respond"
 
-    return "policy"
+    return "validate"
 
 
 def build_agent_graph(registry: Any) -> StateGraph:
@@ -66,6 +78,7 @@ def build_agent_graph(registry: Any) -> StateGraph:
     graph.add_node("parse", parse_node)
     graph.add_node("disambiguate", disambiguate_node)
     graph.add_node("plan", plan_node)
+    graph.add_node("validate", validate_node)
     graph.add_node("policy", policy_node)
     graph.add_node("confirm", confirm_node)
     graph.add_node("execute", execute_node_wrapped)
@@ -82,7 +95,11 @@ def build_agent_graph(registry: Any) -> StateGraph:
     )
 
     graph.add_edge("disambiguate", "plan")
-    graph.add_edge("plan", "policy")
+    graph.add_edge("plan", "validate")
+
+    graph.add_conditional_edges(
+        "validate", route_after_validate, {"policy": "policy", "respond": "respond"}
+    )
 
     graph.add_conditional_edges(
         "policy", route_after_policy, {"execute": "execute", "respond": "respond"}
@@ -97,7 +114,7 @@ def build_agent_graph(registry: Any) -> StateGraph:
     graph.add_edge("verify", "update")
 
     graph.add_conditional_edges(
-        "update", route_after_update, {"policy": "policy", "respond": "respond"}
+        "update", route_after_update, {"validate": "validate", "respond": "respond"}
     )
 
     graph.add_edge("respond", END)

--- a/xfusion/planning/__init__.py
+++ b/xfusion/planning/__init__.py
@@ -1,0 +1,5 @@
+from __future__ import annotations
+
+from xfusion.planning.validator import PlanValidationError, PlanValidationResult, validate_plan
+
+__all__ = ["PlanValidationError", "PlanValidationResult", "validate_plan"]

--- a/xfusion/planning/reference_resolver.py
+++ b/xfusion/planning/reference_resolver.py
@@ -1,0 +1,122 @@
+from __future__ import annotations
+
+from typing import Any
+
+from xfusion.domain.enums import StepStatus
+from xfusion.domain.models.execution_plan import ExecutionPlan
+from xfusion.planning.validator import REFERENCE_RE
+
+
+def _resolve_output_path(output_data: dict[str, Any], attr: str) -> Any:
+    if "[" in attr and attr.endswith("]"):
+        key, idx_str = attr.rstrip("]").split("[", 1)
+        idx = int(idx_str)
+        value = output_data[key]
+        if not isinstance(value, list):
+            raise ValueError(f"Attribute '{key}' is not a list.")
+        return value[idx]
+    return output_data[attr]
+
+
+def _require_authorized_output(
+    *,
+    plan: ExecutionPlan,
+    step_id: str,
+    authorized_outputs: dict[str, dict[str, Any]],
+) -> dict[str, Any]:
+    upstream_step = next((step for step in plan.steps if step.step_id == step_id), None)
+    if upstream_step is None:
+        raise ValueError(f"Referenced step '{step_id}' does not exist.")
+    if upstream_step.status != StepStatus.SUCCESS or not upstream_step.authorized_output_accepted:
+        raise ValueError(
+            f"Referenced step '{step_id}' is not a successful authorized upstream output."
+        )
+    if step_id not in authorized_outputs:
+        raise ValueError(f"Referenced step '{step_id}' output not found.")
+    return authorized_outputs[step_id]
+
+
+def resolve_reference(
+    reference: str,
+    *,
+    plan: ExecutionPlan,
+    authorized_outputs: dict[str, dict[str, Any]],
+) -> Any:
+    """Resolve canonical v0.2 $steps.<id>.outputs.<field> references."""
+    match = REFERENCE_RE.match(reference)
+    if match is None:
+        raise ValueError(f"Invalid reference syntax: {reference}")
+
+    step_id = match.group("step_id")
+    field = match.group("field")
+    index = match.group("index")
+    attr = f"{field}[{index}]" if index is not None else field
+    output_data = _require_authorized_output(
+        plan=plan,
+        step_id=step_id,
+        authorized_outputs=authorized_outputs,
+    )
+    try:
+        return _resolve_output_path(output_data, attr)
+    except (KeyError, IndexError, ValueError) as e:
+        raise ValueError(f"Failed to resolve reference '{reference}': {e}") from e
+
+
+def resolve_legacy_ref(
+    ref: str,
+    *,
+    plan: ExecutionPlan,
+    authorized_outputs: dict[str, dict[str, Any]],
+) -> Any:
+    """Reject legacy references; v0.2 requires canonical $steps references."""
+    raise ValueError(
+        "Legacy reference syntax is forbidden in v0.2; "
+        f"use canonical $steps.<id>.outputs.<field> syntax instead: {ref}"
+    )
+
+
+def resolve_value(
+    value: Any,
+    *,
+    plan: ExecutionPlan,
+    authorized_outputs: dict[str, dict[str, Any]],
+) -> Any:
+    if isinstance(value, str) and value.startswith("$steps."):
+        return resolve_reference(value, plan=plan, authorized_outputs=authorized_outputs)
+
+    if isinstance(value, dict) and "ref" in value:
+        return resolve_legacy_ref(
+            str(value["ref"]),
+            plan=plan,
+            authorized_outputs=authorized_outputs,
+        )
+
+    if isinstance(value, dict):
+        return {
+            key: resolve_value(nested, plan=plan, authorized_outputs=authorized_outputs)
+            for key, nested in value.items()
+        }
+
+    if isinstance(value, list):
+        return [
+            resolve_value(nested, plan=plan, authorized_outputs=authorized_outputs)
+            for nested in value
+        ]
+
+    return value
+
+
+def resolve_args(
+    args: dict[str, object],
+    *,
+    plan: ExecutionPlan,
+    authorized_outputs: dict[str, dict[str, Any]] | None = None,
+    step_outputs: dict[str, dict[str, Any]] | None = None,
+) -> dict[str, object]:
+    # ``step_outputs`` is accepted only for old tests; v0.2 callers must pass
+    # accepted authorized outputs.
+    outputs = authorized_outputs if authorized_outputs is not None else step_outputs or {}
+    return {
+        key: resolve_value(value, plan=plan, authorized_outputs=outputs)
+        for key, value in args.items()
+    }

--- a/xfusion/planning/validator.py
+++ b/xfusion/planning/validator.py
@@ -1,0 +1,376 @@
+from __future__ import annotations
+
+import re
+from collections import defaultdict, deque
+from collections.abc import Iterable
+from typing import Any, cast
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from xfusion.capabilities.registry import CapabilityRegistry
+from xfusion.domain.models.capability import CapabilityDefinition
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+
+REFERENCE_RE = re.compile(
+    r"^\$steps\.(?P<step_id>[A-Za-z_][A-Za-z0-9_-]*)\.outputs\."
+    r"(?P<field>[A-Za-z_][A-Za-z0-9_]*)(?:\[(?P<index>[0-9]+)\])?$"
+)
+
+
+class PlanValidationError(BaseModel):
+    """Structured v0.2 plan validation error."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    code: str = Field(min_length=1)
+    message: str = Field(min_length=1)
+    step_id: str | None = None
+
+
+class PlanValidationResult(BaseModel):
+    """Validation result for a v0.2 execution plan."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    errors: list[PlanValidationError] = Field(default_factory=list)
+
+
+def _iter_references(value: Any) -> Iterable[str]:
+    if isinstance(value, str) and value.startswith("$steps."):
+        yield value
+    elif isinstance(value, dict):
+        for nested in value.values():
+            yield from _iter_references(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from _iter_references(nested)
+
+
+def _iter_legacy_refs(value: Any) -> Iterable[str]:
+    if isinstance(value, dict) and "ref" in value:
+        yield str(value["ref"])
+    elif isinstance(value, dict):
+        for nested in value.values():
+            yield from _iter_legacy_refs(nested)
+    elif isinstance(value, list):
+        for nested in value:
+            yield from _iter_legacy_refs(nested)
+
+
+def _split_legacy_ref(ref: str) -> tuple[str, str] | None:
+    parts = ref.split(".", 1)
+    if len(parts) != 2:
+        return None
+    step_id, attr = parts
+    field = attr.split("[", 1)[0]
+    if not step_id or not field:
+        return None
+    return step_id, field
+
+
+def _declared_output_fields(capability_output_schema: dict[str, object]) -> set[str]:
+    properties = capability_output_schema.get("properties")
+    if not isinstance(properties, dict):
+        return set()
+    return {str(field) for field in properties}
+
+
+def _validate_acyclic(steps: list[PlanStep]) -> bool:
+    step_ids = {str(step.step_id) for step in steps}
+    incoming_count = {step_id: 0 for step_id in step_ids}
+    outgoing: dict[str, list[str]] = defaultdict(list)
+
+    for step in steps:
+        step_id = str(step.step_id)
+        for dep in step.dependencies:
+            if dep not in step_ids:
+                continue
+            incoming_count[step_id] += 1
+            outgoing[dep].append(step_id)
+
+    queue = deque(step_id for step_id, count in incoming_count.items() if count == 0)
+    visited = 0
+    while queue:
+        step_id = queue.popleft()
+        visited += 1
+        for dependent in outgoing[step_id]:
+            incoming_count[dependent] -= 1
+            if incoming_count[dependent] == 0:
+                queue.append(dependent)
+
+    return visited == len(step_ids)
+
+
+def _schema_type_matches(value: object, schema: dict[str, object]) -> bool:
+    expected_type = schema.get("type")
+    if expected_type == "integer":
+        return isinstance(value, int) and not isinstance(value, bool)
+    if expected_type == "number":
+        return isinstance(value, int | float) and not isinstance(value, bool)
+    if expected_type == "string":
+        return isinstance(value, str)
+    if expected_type == "boolean":
+        return isinstance(value, bool)
+    if expected_type == "array":
+        return isinstance(value, list)
+    if expected_type == "object":
+        return isinstance(value, dict)
+    return True
+
+
+def _schema_constraint_errors(value: object, schema: dict[str, object]) -> list[str]:
+    errors: list[str] = []
+    enum_values = schema.get("enum")
+    if isinstance(enum_values, list) and value not in enum_values:
+        errors.append("arg_enum_violation")
+
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        minimum = schema.get("minimum")
+        maximum = schema.get("maximum")
+        if isinstance(minimum, int | float) and value < minimum:
+            errors.append("arg_range_violation")
+        if isinstance(maximum, int | float) and value > maximum:
+            errors.append("arg_range_violation")
+
+    if isinstance(value, str):
+        min_length = schema.get("minLength")
+        max_length = schema.get("maxLength")
+        if isinstance(min_length, int) and len(value) < min_length:
+            errors.append("arg_length_violation")
+        if isinstance(max_length, int) and len(value) > max_length:
+            errors.append("arg_length_violation")
+
+    if isinstance(value, list):
+        min_items = schema.get("minItems")
+        max_items = schema.get("maxItems")
+        if isinstance(min_items, int) and len(value) < min_items:
+            errors.append("arg_length_violation")
+        if isinstance(max_items, int) and len(value) > max_items:
+            errors.append("arg_length_violation")
+
+    return errors
+
+
+def _validate_literal_args(
+    *,
+    step: PlanStep,
+    input_schema: dict[str, object],
+    errors: list[PlanValidationError],
+) -> None:
+    properties = input_schema.get("properties")
+    required = input_schema.get("required")
+    if not isinstance(properties, dict):
+        properties = {}
+    if not isinstance(required, list):
+        required = []
+    typed_properties = cast(dict[str, object], properties)
+
+    for required_name in required:
+        if str(required_name) not in step.args:
+            errors.append(
+                PlanValidationError(
+                    code="missing_required_arg",
+                    step_id=step.step_id,
+                    message=f"Step '{step.step_id}' missing required arg '{required_name}'.",
+                )
+            )
+
+    for arg_name, arg_value in step.args.items():
+        if arg_name not in typed_properties:
+            errors.append(
+                PlanValidationError(
+                    code="unknown_arg",
+                    step_id=step.step_id,
+                    message=f"Step '{step.step_id}' arg '{arg_name}' is not in capability schema.",
+                )
+            )
+            continue
+        if isinstance(arg_value, str) and arg_value.startswith("$steps."):
+            continue
+        if isinstance(arg_value, dict) and "ref" in arg_value:
+            continue
+        arg_schema = typed_properties[arg_name]
+        if isinstance(arg_schema, dict) and not _schema_type_matches(
+            arg_value, cast(dict[str, object], arg_schema)
+        ):
+            errors.append(
+                PlanValidationError(
+                    code="arg_type_mismatch",
+                    step_id=step.step_id,
+                    message=f"Step '{step.step_id}' arg '{arg_name}' does not match schema.",
+                )
+            )
+            continue
+        if isinstance(arg_schema, dict):
+            for constraint_code in _schema_constraint_errors(
+                arg_value, cast(dict[str, object], arg_schema)
+            ):
+                errors.append(
+                    PlanValidationError(
+                        code=constraint_code,
+                        step_id=step.step_id,
+                        message=(
+                            f"Step '{step.step_id}' arg '{arg_name}' violates "
+                            "capability schema constraints."
+                        ),
+                    )
+                )
+
+
+def validate_plan(
+    plan: ExecutionPlan,
+    registry: CapabilityRegistry,
+) -> PlanValidationResult:
+    """Validate v0.2 static plan constraints before policy or execution."""
+    errors: list[PlanValidationError] = []
+    step_ids = [str(step.step_id) for step in plan.steps]
+    step_id_set = set(step_ids)
+
+    if len(step_ids) != len(step_id_set):
+        errors.append(
+            PlanValidationError(
+                code="duplicate_step_id",
+                message="Plan contains duplicate step ids.",
+            )
+        )
+
+    if not _validate_acyclic(plan.steps):
+        errors.append(
+            PlanValidationError(
+                code="cyclic_dependency_graph",
+                message="Plan dependency graph contains a cycle.",
+            )
+        )
+
+    has_mutation = False
+    capabilities_by_step: dict[str, CapabilityDefinition] = {}
+
+    for step in plan.steps:
+        capability_name = str(step.capability)
+        capability = registry.get(capability_name)
+        if capability is None:
+            errors.append(
+                PlanValidationError(
+                    code="unknown_capability",
+                    step_id=step.step_id,
+                    message=f"Unknown capability '{capability_name}'.",
+                )
+            )
+            continue
+
+        capabilities_by_step[str(step.step_id)] = capability
+        has_mutation = has_mutation or not capability.is_read_only
+        _validate_literal_args(step=step, input_schema=capability.input_schema, errors=errors)
+
+        for dep in step.dependencies:
+            if dep not in step_id_set:
+                errors.append(
+                    PlanValidationError(
+                        code="unknown_dependency",
+                        step_id=step.step_id,
+                        message=f"Step '{step.step_id}' depends on unknown step '{dep}'.",
+                    )
+                )
+
+        for reference in _iter_references(step.args):
+            match = REFERENCE_RE.match(reference)
+            if match is None:
+                errors.append(
+                    PlanValidationError(
+                        code="invalid_reference_syntax",
+                        step_id=step.step_id,
+                        message=f"Invalid reference syntax: {reference}",
+                    )
+                )
+                continue
+
+            ref_step_id = match.group("step_id")
+            ref_field = match.group("field")
+            if ref_step_id not in step_id_set:
+                errors.append(
+                    PlanValidationError(
+                        code="unknown_reference_step",
+                        step_id=step.step_id,
+                        message=f"Reference points to unknown step '{ref_step_id}'.",
+                    )
+                )
+                continue
+
+            if ref_step_id not in step.dependencies:
+                errors.append(
+                    PlanValidationError(
+                        code="reference_not_dependency",
+                        step_id=step.step_id,
+                        message=(
+                            f"Reference to '{ref_step_id}' is not declared as a dependency "
+                            f"of step '{step.step_id}'."
+                        ),
+                    )
+                )
+
+            upstream_capability = capabilities_by_step.get(ref_step_id)
+            if upstream_capability is None:
+                upstream_step = next(
+                    (candidate for candidate in plan.steps if candidate.step_id == ref_step_id),
+                    None,
+                )
+                if upstream_step is not None:
+                    upstream_capability = registry.get(str(upstream_step.capability))
+            if upstream_capability is None:
+                continue
+
+            declared_fields = _declared_output_fields(upstream_capability.output_schema)
+            if declared_fields and ref_field not in declared_fields:
+                errors.append(
+                    PlanValidationError(
+                        code="unknown_reference_output",
+                        step_id=step.step_id,
+                        message=(
+                            f"Reference field '{ref_field}' is not declared by "
+                            f"capability '{upstream_capability.name}'."
+                        ),
+                    )
+                )
+
+        for legacy_ref in _iter_legacy_refs(step.args):
+            errors.append(
+                PlanValidationError(
+                    code="legacy_reference_forbidden",
+                    step_id=step.step_id,
+                    message=(
+                        "Legacy {'ref': ...} references are forbidden in v0.2; "
+                        f"use canonical $steps.<id>.outputs.<field> syntax instead: {legacy_ref}"
+                    ),
+                )
+            )
+
+    if has_mutation and not plan.verification_strategy:
+        errors.append(
+            PlanValidationError(
+                code="missing_verification_strategy",
+                message="Mutating workflow requires a verification strategy.",
+            )
+        )
+
+    if has_mutation and not plan.verification_no_meaningful_verifier:
+        verification_steps = {
+            verification_step_id
+            for step in plan.steps
+            for verification_step_id in step.verification_step_ids
+        }
+        has_explicit_verification_step = any(
+            step.step_id in verification_steps for step in plan.steps
+        )
+        if not has_explicit_verification_step and len(plan.steps) > 1:
+            errors.append(
+                PlanValidationError(
+                    code="missing_explicit_verification_step",
+                    message=(
+                        "Mutating workflow requires an explicit verification step unless "
+                        "no meaningful verifier exists."
+                    ),
+                )
+            )
+
+    return PlanValidationResult(valid=not errors, errors=errors)

--- a/xfusion/planning/validator.py
+++ b/xfusion/planning/validator.py
@@ -8,6 +8,7 @@ from typing import Any, cast
 from pydantic import BaseModel, ConfigDict, Field
 
 from xfusion.capabilities.registry import CapabilityRegistry
+from xfusion.capabilities.schema import validate_schema_value
 from xfusion.domain.models.capability import CapabilityDefinition
 from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
 
@@ -102,54 +103,35 @@ def _validate_acyclic(steps: list[PlanStep]) -> bool:
     return visited == len(step_ids)
 
 
-def _schema_type_matches(value: object, schema: dict[str, object]) -> bool:
-    expected_type = schema.get("type")
-    if expected_type == "integer":
-        return isinstance(value, int) and not isinstance(value, bool)
-    if expected_type == "number":
-        return isinstance(value, int | float) and not isinstance(value, bool)
-    if expected_type == "string":
-        return isinstance(value, str)
-    if expected_type == "boolean":
-        return isinstance(value, bool)
-    if expected_type == "array":
-        return isinstance(value, list)
-    if expected_type == "object":
-        return isinstance(value, dict)
-    return True
-
-
-def _schema_constraint_errors(value: object, schema: dict[str, object]) -> list[str]:
-    errors: list[str] = []
-    enum_values = schema.get("enum")
-    if isinstance(enum_values, list) and value not in enum_values:
-        errors.append("arg_enum_violation")
-
-    if isinstance(value, int | float) and not isinstance(value, bool):
-        minimum = schema.get("minimum")
-        maximum = schema.get("maximum")
-        if isinstance(minimum, int | float) and value < minimum:
-            errors.append("arg_range_violation")
-        if isinstance(maximum, int | float) and value > maximum:
-            errors.append("arg_range_violation")
-
-    if isinstance(value, str):
-        min_length = schema.get("minLength")
-        max_length = schema.get("maxLength")
-        if isinstance(min_length, int) and len(value) < min_length:
-            errors.append("arg_length_violation")
-        if isinstance(max_length, int) and len(value) > max_length:
-            errors.append("arg_length_violation")
-
-    if isinstance(value, list):
-        min_items = schema.get("minItems")
-        max_items = schema.get("maxItems")
-        if isinstance(min_items, int) and len(value) < min_items:
-            errors.append("arg_length_violation")
-        if isinstance(max_items, int) and len(value) > max_items:
-            errors.append("arg_length_violation")
-
-    return errors
+def _schema_error_code(error: str) -> str:
+    if "not one of" in error:
+        return "arg_enum_violation"
+    if any(
+        marker in error
+        for marker in (
+            "below minimum",
+            "above maximum",
+            "exclusiveMinimum",
+            "exclusiveMaximum",
+            "multipleOf",
+        )
+    ):
+        return "arg_range_violation"
+    if any(
+        marker in error
+        for marker in (
+            "minLength",
+            "maxLength",
+            "minItems",
+            "maxItems",
+            "minProperties",
+            "maxProperties",
+        )
+    ):
+        return "arg_length_violation"
+    if "expected" in error:
+        return "arg_type_mismatch"
+    return "arg_schema_violation"
 
 
 def _validate_literal_args(
@@ -191,31 +173,29 @@ def _validate_literal_args(
         if isinstance(arg_value, dict) and "ref" in arg_value:
             continue
         arg_schema = typed_properties[arg_name]
-        if isinstance(arg_schema, dict) and not _schema_type_matches(
-            arg_value, cast(dict[str, object], arg_schema)
-        ):
+        if not isinstance(arg_schema, dict):
             errors.append(
                 PlanValidationError(
-                    code="arg_type_mismatch",
+                    code="arg_schema_violation",
                     step_id=step.step_id,
-                    message=f"Step '{step.step_id}' arg '{arg_name}' does not match schema.",
+                    message=f"Step '{step.step_id}' arg '{arg_name}' has invalid schema.",
                 )
             )
             continue
-        if isinstance(arg_schema, dict):
-            for constraint_code in _schema_constraint_errors(
-                arg_value, cast(dict[str, object], arg_schema)
-            ):
-                errors.append(
-                    PlanValidationError(
-                        code=constraint_code,
-                        step_id=step.step_id,
-                        message=(
-                            f"Step '{step.step_id}' arg '{arg_name}' violates "
-                            "capability schema constraints."
-                        ),
-                    )
+        schema_result = validate_schema_value(
+            arg_value, cast(dict[str, Any], arg_schema), path=f"$.{arg_name}"
+        )
+        for validation_error in schema_result.errors:
+            errors.append(
+                PlanValidationError(
+                    code=_schema_error_code(validation_error),
+                    step_id=step.step_id,
+                    message=(
+                        f"Step '{step.step_id}' arg '{arg_name}' violates "
+                        f"capability schema constraints: {validation_error}"
+                    ),
                 )
+            )
 
 
 def validate_plan(

--- a/xfusion/policy/approval.py
+++ b/xfusion/policy/approval.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from datetime import UTC, datetime, timedelta
+from typing import Any
+from uuid import uuid4
+
+from xfusion.domain.enums import ApprovalMode, RiskTier
+from xfusion.domain.models.approval import ApprovalRecord, PreviewPayload
+from xfusion.domain.models.capability import CapabilityDefinition
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+
+
+def canonical_json(value: Any) -> str:
+    return json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+
+
+def stable_hash(value: Any) -> str:
+    return hashlib.sha256(canonical_json(value).encode("utf-8")).hexdigest()
+
+
+def build_argument_provenance(args: dict[str, Any]) -> dict[str, str]:
+    provenance: dict[str, str] = {}
+    for key, value in args.items():
+        if isinstance(value, str) and value.startswith("$steps."):
+            provenance[key] = f"reference:{value}"
+        else:
+            provenance[key] = "literal_or_validated_user_input"
+    return provenance
+
+
+def build_referenced_output_fingerprints(
+    args: dict[str, Any],
+    authorized_outputs: dict[str, dict[str, Any]],
+) -> dict[str, str]:
+    fingerprints: dict[str, str] = {}
+    for step_id, output in authorized_outputs.items():
+        if f"$steps.{step_id}.outputs." in canonical_json(args):
+            fingerprints[step_id] = stable_hash(output)
+    return fingerprints
+
+
+def build_action_fingerprint(
+    *,
+    capability: CapabilityDefinition,
+    normalized_args: dict[str, Any],
+    argument_provenance: dict[str, str],
+    target_context: dict[str, Any],
+    approval_mode: ApprovalMode,
+    risk_tier: RiskTier,
+    referenced_output_fingerprints: dict[str, str],
+    grouped_mutations: list[str] | None = None,
+) -> str:
+    payload = {
+        "capability": capability.name,
+        "capability_version": capability.version,
+        "adapter_id": capability.adapter_id,
+        "normalized_args": normalized_args,
+        "argument_provenance": argument_provenance,
+        "target_context": target_context,
+        "approval_mode": approval_mode,
+        "risk_tier": risk_tier,
+        "referenced_output_fingerprints": referenced_output_fingerprints,
+        "grouped_mutations": grouped_mutations or [capability.name],
+    }
+    return stable_hash(payload)
+
+
+def build_preview_payload(
+    *,
+    capability: CapabilityDefinition,
+    step: PlanStep,
+    normalized_args: dict[str, Any],
+    argument_provenance: dict[str, str],
+    approval_mode: ApprovalMode,
+    expires_at: datetime,
+) -> PreviewPayload:
+    impacted_target = str(
+        normalized_args.get("path")
+        or normalized_args.get("pid")
+        or normalized_args.get("service")
+        or normalized_args.get("username")
+        or capability.object
+    )
+    action_summary = (
+        step.preview_summary or step.justification or f"{capability.verb} {capability.object}"
+    )
+    return PreviewPayload(
+        impacted_target=impacted_target,
+        action_summary=action_summary,
+        reversibility_estimate="bounded" if capability.risk_tier == RiskTier.TIER_1 else "limited",
+        expected_blast_radius="single declared target/scope",
+        capability=capability.name,
+        normalized_args=normalized_args,
+        argument_provenance_summary=argument_provenance,
+        rollback_notes=step.fallback_action or None,
+        approval_mode=approval_mode,
+        expiry=expires_at,
+    )
+
+
+def create_approval_record(
+    *,
+    plan: ExecutionPlan,
+    step: PlanStep,
+    capability: CapabilityDefinition,
+    normalized_args: dict[str, Any],
+    target_context: dict[str, Any],
+    approval_mode: ApprovalMode,
+    risk_tier: RiskTier,
+    authorized_outputs: dict[str, dict[str, Any]],
+    ttl_minutes: int = 10,
+) -> ApprovalRecord:
+    expires_at = datetime.now(UTC) + timedelta(minutes=ttl_minutes)
+    provenance = build_argument_provenance(step.args)
+    referenced_output_fingerprints = build_referenced_output_fingerprints(
+        step.args, authorized_outputs
+    )
+    fingerprint = build_action_fingerprint(
+        capability=capability,
+        normalized_args=normalized_args,
+        argument_provenance=provenance,
+        target_context=target_context,
+        approval_mode=approval_mode,
+        risk_tier=risk_tier,
+        referenced_output_fingerprints=referenced_output_fingerprints,
+    )
+    approval_id = f"apr_{uuid4().hex[:12]}"
+    phrase = f"APPROVE {approval_id} {fingerprint[:12]}"
+    preview = build_preview_payload(
+        capability=capability,
+        step=step,
+        normalized_args=normalized_args,
+        argument_provenance=provenance,
+        approval_mode=approval_mode,
+        expires_at=expires_at,
+    )
+    return ApprovalRecord(
+        approval_id=approval_id,
+        plan_id=plan.plan_id,
+        step_id=step.step_id,
+        normalized_capability_set=[capability.name],
+        target_context=target_context,
+        action_fingerprint=fingerprint,
+        referenced_output_fingerprints=referenced_output_fingerprints,
+        approval_mode=approval_mode,
+        risk_tier=risk_tier,
+        adapter_id=capability.adapter_id,
+        capability_version=capability.version,
+        preview=preview,
+        typed_confirmation_phrase=phrase,
+        expires_at=expires_at,
+    )
+
+
+def validate_approval_for_invocation(
+    *,
+    approval: ApprovalRecord,
+    capability: CapabilityDefinition,
+    normalized_args: dict[str, Any],
+    target_context: dict[str, Any],
+    approval_mode: ApprovalMode,
+    risk_tier: RiskTier,
+    argument_provenance: dict[str, str],
+    referenced_output_fingerprints: dict[str, str],
+) -> tuple[bool, str]:
+    if not approval.is_approved:
+        return False, "approval_not_approved"
+    if approval.is_expired():
+        return False, "approval_expired"
+    current = build_action_fingerprint(
+        capability=capability,
+        normalized_args=normalized_args,
+        argument_provenance=argument_provenance,
+        target_context=target_context,
+        approval_mode=approval_mode,
+        risk_tier=risk_tier,
+        referenced_output_fingerprints=referenced_output_fingerprints,
+    )
+    if current != approval.action_fingerprint:
+        return False, "material_change"
+    return True, "approval_valid"

--- a/xfusion/policy/rules.py
+++ b/xfusion/policy/rules.py
@@ -1,110 +1,239 @@
 from __future__ import annotations
 
-from xfusion.domain.enums import RiskLevel
+from typing import Any
+
+from xfusion.capabilities.registry import build_default_capability_registry
+from xfusion.domain.enums import ApprovalMode, PolicyDecisionValue, RiskTier
+from xfusion.domain.models.capability import CapabilityDefinition
 from xfusion.domain.models.environment import EnvironmentState
 from xfusion.domain.models.policy import PolicyDecision
 from xfusion.policy.protected_paths import is_protected
+from xfusion.security.secrets import is_secret_path
+
+
+def _decision(
+    *,
+    decision: PolicyDecisionValue,
+    matched_rule_id: str,
+    capability: CapabilityDefinition | None,
+    risk_tier: RiskTier,
+    approval_mode: ApprovalMode,
+    reason: str,
+    reason_codes: list[str],
+    constraints_applied: list[str] | None = None,
+    extra_explainability: dict[str, Any] | None = None,
+) -> PolicyDecision:
+    return PolicyDecision(
+        decision=decision,
+        matched_rule_id=matched_rule_id,
+        risk_tier=risk_tier,
+        approval_mode=approval_mode,
+        constraints_applied=constraints_applied or [],
+        reason_codes=reason_codes,
+        explainability_record={
+            "capability": capability.name if capability else None,
+            "capability_version": capability.version if capability else None,
+            "matched_rule_id": matched_rule_id,
+            "constraints_applied": constraints_applied or [],
+            "approval_mode": approval_mode,
+            "decision": decision,
+            "reason_codes": reason_codes,
+            **(extra_explainability or {}),
+        },
+        reason=reason,
+    )
+
+
+def _target_paths(args: dict[str, object]) -> list[str]:
+    paths: list[str] = []
+    if isinstance(args.get("path"), str):
+        paths.append(str(args["path"]))
+    approved_paths = args.get("approved_paths")
+    if isinstance(approved_paths, list):
+        paths.extend(str(path) for path in approved_paths)
+    raw_paths = args.get("paths")
+    if isinstance(raw_paths, list):
+        paths.extend(str(path) for path in raw_paths)
+    return paths
 
 
 def evaluate_policy(
     *,
-    tool: str,
-    parameters: dict[str, object],
+    capability_name: str | None = None,
+    resolved_args: dict[str, object] | None = None,
+    argument_provenance: dict[str, str] | None = None,
     environment: EnvironmentState,
+    actor_type: str = "assistant",
+    host_class: str = "production",
+    target_scope: str = "explicit",
+    request_intent: str = "operation",
+    prior_approval_state: dict[str, object] | None = None,
+    time_quota_context: dict[str, object] | None = None,
+    tool: str | None = None,
+    parameters: dict[str, object] | None = None,
 ) -> PolicyDecision:
-    """Return deterministic policy decision for one planned tool call."""
+    """Return the v0.2 deterministic policy decision for a capability invocation.
 
-    # Read-only tools are generally low risk
-    if (
-        tool.startswith("system.detect")
-        or tool.startswith("system.check")
-        or tool == "system.current_user"
-        or tool == "system.service_status"
-        or tool.startswith("disk.check")
-        or tool.startswith("disk.find")
-        or tool.startswith("file.search")
-        or tool.startswith("file.preview")
-        or tool.startswith("process.list")
-        or tool.startswith("process.find")
-    ):
-        return PolicyDecision(
-            risk_level=RiskLevel.LOW,
-            allowed=True,
-            requires_confirmation=False,
-            reason="Read-only operation is low risk.",
+    ``tool`` and ``parameters`` are accepted only as an isolated migration shim for
+    older callers; the authoritative inputs are ``capability_name`` and
+    ``resolved_args``.
+    """
+    name = capability_name or tool or ""
+    args = resolved_args if resolved_args is not None else parameters or {}
+    registry = build_default_capability_registry()
+    capability = registry.get(name)
+
+    if capability is None:
+        return _decision(
+            decision=PolicyDecisionValue.DENY,
+            matched_rule_id="default.deny_unknown_capability",
+            capability=None,
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            reason=f"Unknown capability '{name}' is denied by default.",
+            reason_codes=["unknown_capability", "deny_by_default"],
         )
 
-    if tool == "plan.explain_action":
-        path = str(parameters.get("path", "the requested path"))
-        action = str(parameters.get("action", "action"))
-        return PolicyDecision(
-            risk_level=RiskLevel.FORBIDDEN,
-            allowed=False,
-            requires_confirmation=False,
+    if actor_type not in capability.allowed_actor_types:
+        return _decision(
+            decision=PolicyDecisionValue.DENY,
+            matched_rule_id="actor.denied",
+            capability=capability,
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            reason=f"Actor type '{actor_type}' is not allowed for capability '{name}'.",
+            reason_codes=["actor_type_not_allowed"],
+        )
+
+    for path in _target_paths(args):
+        if is_secret_path(path):
+            return _decision(
+                decision=PolicyDecisionValue.DENY,
+                matched_rule_id="secret_path.deny",
+                capability=capability,
+                risk_tier=RiskTier.TIER_3,
+                approval_mode=ApprovalMode.DENY,
+                reason=f"Path '{path}' is known secret material and is denied.",
+                reason_codes=["secret_path", "secret_denied"],
+            )
+        if is_protected(path, environment.protected_paths) and not capability.is_read_only:
+            return _decision(
+                decision=PolicyDecisionValue.DENY,
+                matched_rule_id="protected_path.deny_mutation",
+                capability=capability,
+                risk_tier=RiskTier.TIER_3,
+                approval_mode=ApprovalMode.DENY,
+                reason=f"Path '{path}' is protected and cannot be modified.",
+                reason_codes=["protected_path", "scope_violation"],
+            )
+
+    if target_scope != "explicit":
+        return _decision(
+            decision=PolicyDecisionValue.DENY,
+            matched_rule_id="scope.explicit_required",
+            capability=capability,
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            reason=(
+                f"Capability '{name}' requires explicit target scope; received '{target_scope}'."
+            ),
+            reason_codes=["scope_not_explicit", "deny_by_default"],
+            extra_explainability={
+                "target_scope": target_scope,
+                "request_intent": request_intent,
+                "argument_provenance": argument_provenance or {},
+            },
+        )
+
+    if name == "plan.explain_action":
+        path = str(args.get("path", "the requested path"))
+        action = str(args.get("action", "action"))
+        return _decision(
+            decision=PolicyDecisionValue.DENY,
+            matched_rule_id="protected_path.recursive_permission_change.deny",
+            capability=capability,
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
             reason=(
                 f"Recursive {action} permission changes on protected path '{path}' are forbidden."
             ),
+            reason_codes=["protected_path", "permission_change_forbidden"],
         )
 
-    # Protected path check for any tool that takes a path
-    if "path" in parameters:
-        path = str(parameters["path"])
-        if is_protected(path, environment.protected_paths):
-            return PolicyDecision(
-                risk_level=RiskLevel.FORBIDDEN,
-                allowed=False,
-                requires_confirmation=False,
-                reason=f"Path '{path}' is protected and cannot be modified.",
-            )
-    if "paths" in parameters and isinstance(parameters["paths"], list):
-        for raw_path in parameters["paths"]:
-            path = str(raw_path)
-            if is_protected(path, environment.protected_paths):
-                return PolicyDecision(
-                    risk_level=RiskLevel.FORBIDDEN,
-                    allowed=False,
-                    requires_confirmation=False,
-                    reason=f"Path '{path}' is protected and cannot be modified.",
-                )
-
-    # Process kill is medium risk
-    if tool == "process.kill":
-        return PolicyDecision(
-            risk_level=RiskLevel.MEDIUM,
-            allowed=True,
-            requires_confirmation=True,
-            reason="Stopping a process can affect system services and requires confirmation.",
+    if capability.risk_tier == RiskTier.TIER_3 or capability.approval_mode == ApprovalMode.DENY:
+        return _decision(
+            decision=PolicyDecisionValue.DENY,
+            matched_rule_id="tier3.deny",
+            capability=capability,
+            risk_tier=RiskTier.TIER_3,
+            approval_mode=ApprovalMode.DENY,
+            reason=f"Capability '{name}' is prohibited or broad impact.",
+            reason_codes=["tier_3_denied"],
         )
 
-    # User creation/deletion is medium risk
-    if tool in {"user.create", "user.delete"}:
-        return PolicyDecision(
-            risk_level=RiskLevel.MEDIUM,
-            allowed=True,
-            requires_confirmation=True,
-            reason=f"Modifying system users ({tool}) requires confirmation.",
+    if capability.risk_tier == RiskTier.TIER_0 and capability.is_read_only:
+        return _decision(
+            decision=PolicyDecisionValue.ALLOW,
+            matched_rule_id="tier0.read_only.explicit_scope.allow",
+            capability=capability,
+            risk_tier=RiskTier.TIER_0,
+            approval_mode=ApprovalMode.AUTO,
+            constraints_applied=["explicit_scope", "read_only", "network_denied"],
+            reason="Tier 0 read-only capability is allowed within explicit scope.",
+            reason_codes=["tier_0_read_only_allowed"],
+            extra_explainability={
+                "argument_provenance": argument_provenance or {},
+                "host_class": host_class,
+                "target_scope": target_scope,
+                "request_intent": request_intent,
+            },
         )
 
-    # Cleanup is medium risk
-    if tool == "cleanup.safe_disk_cleanup":
-        if parameters.get("execute") is not True:
-            return PolicyDecision(
-                risk_level=RiskLevel.LOW,
-                allowed=True,
-                requires_confirmation=False,
+    if capability.risk_tier == RiskTier.TIER_1:
+        if name == "cleanup.safe_disk_cleanup" and args.get("execute") is not True:
+            return _decision(
+                decision=PolicyDecisionValue.ALLOW,
+                matched_rule_id="tier1.cleanup_preview.allow",
+                capability=capability,
+                risk_tier=RiskTier.TIER_0,
+                approval_mode=ApprovalMode.AUTO,
+                constraints_applied=["preview_only", "bounded_candidates", "network_denied"],
                 reason="Cleanup preview is read-only and bounded to approved candidates.",
+                reason_codes=["preview_allowed"],
             )
-        return PolicyDecision(
-            risk_level=RiskLevel.MEDIUM,
-            allowed=True,
-            requires_confirmation=True,
-            reason="File cleanup deletes approved candidates and requires confirmation.",
+        return _decision(
+            decision=PolicyDecisionValue.REQUIRE_APPROVAL,
+            matched_rule_id="tier1.mutation.human_approval",
+            capability=capability,
+            risk_tier=RiskTier.TIER_1,
+            approval_mode=ApprovalMode.HUMAN,
+            constraints_applied=["explicit_target", "human_approval_required", "network_denied"],
+            reason=f"Capability '{name}' is a bounded mutation and requires human approval.",
+            reason_codes=["tier_1_requires_human_approval"],
+            extra_explainability={
+                "prior_approval_state": prior_approval_state or {},
+                "time_quota_context": time_quota_context or {},
+            },
         )
 
-    # Default to forbidden for unknown mutating tools
-    return PolicyDecision(
-        risk_level=RiskLevel.FORBIDDEN,
-        allowed=False,
-        requires_confirmation=False,
-        reason=f"Unknown or unauthorized tool '{tool}'.",
+    if capability.risk_tier == RiskTier.TIER_2:
+        return _decision(
+            decision=PolicyDecisionValue.REQUIRE_APPROVAL,
+            matched_rule_id="tier2.mutation.admin_approval",
+            capability=capability,
+            risk_tier=RiskTier.TIER_2,
+            approval_mode=ApprovalMode.ADMIN,
+            constraints_applied=["admin_approval_required", "explicit_scope"],
+            reason=f"Capability '{name}' is high risk and requires admin approval.",
+            reason_codes=["tier_2_requires_admin_approval"],
+        )
+
+    return _decision(
+        decision=PolicyDecisionValue.DENY,
+        matched_rule_id="default.fail_closed",
+        capability=capability,
+        risk_tier=RiskTier.TIER_3,
+        approval_mode=ApprovalMode.DENY,
+        reason=f"No exact policy rule matched capability '{name}'.",
+        reason_codes=["no_exact_rule", "deny_by_default"],
     )

--- a/xfusion/roles/__init__.py
+++ b/xfusion/roles/__init__.py
@@ -1,0 +1,3 @@
+from xfusion.roles.contracts import RoleContract, build_default_role_contracts
+
+__all__ = ["RoleContract", "build_default_role_contracts"]

--- a/xfusion/roles/contracts.py
+++ b/xfusion/roles/contracts.py
@@ -1,0 +1,142 @@
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from xfusion.domain.enums import ReasoningRole, RiskTier
+
+ROLE_ALLOWED_PROPOSALS: dict[ReasoningRole, tuple[str, ...]] = {
+    ReasoningRole.SUPERVISOR: ("intent", "coordination", "clarification"),
+    ReasoningRole.OBSERVATION: ("tier_0_capability", "missing_evidence"),
+    ReasoningRole.DIAGNOSIS: ("hypothesis", "confidence", "missing_evidence"),
+    ReasoningRole.PLANNING: ("workflow_dag", "verification_strategy"),
+    ReasoningRole.VERIFICATION: ("verification_outcome", "repair_proposal"),
+    ReasoningRole.EXPLANATION: ("audit_summary", "safe_next_step"),
+}
+
+ROLE_RESPONSIBILITIES: dict[ReasoningRole, str] = {
+    ReasoningRole.SUPERVISOR: (
+        "Interpret user intent, coordinate role outputs, and request clarification."
+    ),
+    ReasoningRole.OBSERVATION: (
+        "Propose bounded read-only Tier 0 evidence-gathering capabilities."
+    ),
+    ReasoningRole.DIAGNOSIS: (
+        "Produce advisory hypotheses from typed observations without changing authority."
+    ),
+    ReasoningRole.PLANNING: (
+        "Draft typed workflow DAGs with explicit dependencies, references, and verification."
+    ),
+    ReasoningRole.VERIFICATION: (
+        "Evaluate redacted execution evidence and propose non-authoritative repair ideas."
+    ),
+    ReasoningRole.EXPLANATION: ("Summarize authoritative audited state and safe next steps."),
+}
+
+PROHIBITED_ROLE_AUTHORITIES = frozenset(
+    {
+        "execute",
+        "authorize",
+        "approve",
+        "bypass_policy",
+        "fabricate_output",
+        "consume_unredacted_secret",
+        "alter_audit",
+    }
+)
+
+
+class RoleContract(BaseModel):
+    """Non-authoritative reasoning-role boundary for v0.2."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: ReasoningRole
+    responsibility: str
+    allowed_proposal_types: tuple[str, ...]
+    prohibited_authorities: tuple[str, ...]
+    max_steps: int = Field(ge=1, le=20)
+    max_tokens_hint: int = Field(ge=128, le=16_000)
+    authoritative: bool = False
+
+
+class RoleProposal(BaseModel):
+    """Typed non-authoritative proposal emitted by one reasoning role."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    role: ReasoningRole
+    proposal_type: str = Field(min_length=1)
+    payload: dict[str, Any] = Field(default_factory=dict)
+    requested_authority: list[str] = Field(default_factory=list)
+    consumes_redacted_inputs_only: bool = True
+
+
+class RoleProposalValidationResult(BaseModel):
+    """Deterministic result for role boundary checks."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    valid: bool
+    errors: list[str] = Field(default_factory=list)
+
+
+def build_default_role_contracts() -> dict[ReasoningRole, RoleContract]:
+    """Return explicit role contracts; deterministic infrastructure remains authoritative."""
+    budgets = {
+        ReasoningRole.SUPERVISOR: (6, 2000),
+        ReasoningRole.OBSERVATION: (8, 1500),
+        ReasoningRole.DIAGNOSIS: (6, 1500),
+        ReasoningRole.PLANNING: (10, 2500),
+        ReasoningRole.VERIFICATION: (6, 1500),
+        ReasoningRole.EXPLANATION: (4, 1200),
+    }
+    return {
+        role: RoleContract(
+            role=role,
+            responsibility=ROLE_RESPONSIBILITIES[role],
+            allowed_proposal_types=ROLE_ALLOWED_PROPOSALS[role],
+            prohibited_authorities=tuple(sorted(PROHIBITED_ROLE_AUTHORITIES)),
+            max_steps=budgets[role][0],
+            max_tokens_hint=budgets[role][1],
+            authoritative=False,
+        )
+        for role in ReasoningRole
+    }
+
+
+def validate_role_proposal(
+    proposal: RoleProposal,
+    *,
+    contracts: dict[ReasoningRole, RoleContract] | None = None,
+) -> RoleProposalValidationResult:
+    """Validate a reasoning proposal without granting any execution authority."""
+    role_contracts = contracts or build_default_role_contracts()
+    contract = role_contracts[proposal.role]
+    errors: list[str] = []
+
+    if contract.authoritative:
+        errors.append(f"Role '{proposal.role}' must be non-authoritative.")
+    if proposal.proposal_type not in contract.allowed_proposal_types:
+        errors.append(
+            f"Proposal type '{proposal.proposal_type}' is not allowed for role '{proposal.role}'."
+        )
+
+    requested = {item.lower() for item in proposal.requested_authority}
+    prohibited = requested & PROHIBITED_ROLE_AUTHORITIES
+    if prohibited:
+        errors.append(
+            f"Reasoning roles are non-authoritative and cannot request {sorted(prohibited)!r}."
+        )
+
+    if proposal.role == ReasoningRole.OBSERVATION:
+        risk_tier = proposal.payload.get("risk_tier")
+        if risk_tier is not None and risk_tier != RiskTier.TIER_0.value:
+            errors.append("Observation proposals may only target Tier 0 capabilities.")
+    if proposal.role == ReasoningRole.VERIFICATION and not proposal.consumes_redacted_inputs_only:
+        errors.append("Verification role proposals may consume only redacted inputs.")
+    if proposal.role == ReasoningRole.EXPLANATION and not proposal.consumes_redacted_inputs_only:
+        errors.append("Explanation role proposals may consume only audited redacted inputs.")
+
+    return RoleProposalValidationResult(valid=not errors, errors=errors)

--- a/xfusion/security/redaction.py
+++ b/xfusion/security/redaction.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import re
+from typing import Any
+
+REDACTION_PATTERNS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    ("aws_access_key", re.compile(r"\bAKIA[0-9A-Z]{16}\b")),
+    (
+        "private_key_block",
+        re.compile(
+            r"-----BEGIN [A-Z ]*PRIVATE KEY-----.*?-----END [A-Z ]*PRIVATE KEY-----",
+            re.DOTALL,
+        ),
+    ),
+    ("bearer_token", re.compile(r"\bBearer\s+[A-Za-z0-9._~+/=-]{16,}\b")),
+    (
+        "assignment_secret",
+        re.compile(
+            r"(?i)\b(api[_-]?key|token|secret|password|passwd|credential)"
+            r"\s*=\s*['\"]?[^'\"\s]{4,}"
+        ),
+    ),
+    (
+        "json_secret",
+        re.compile(
+            r"(?i)(\"(?:api[_-]?key|token|secret|password|credential)\""
+            r"\s*:\s*\")[^\"]+(\")"
+        ),
+    ),
+)
+
+
+def redact_text(value: str) -> tuple[str, dict[str, int]]:
+    """Redact common credential shapes deterministically."""
+    redacted = value
+    counts: dict[str, int] = {}
+    for name, pattern in REDACTION_PATTERNS:
+        if name == "json_secret":
+            redacted, count = pattern.subn(r"\1[REDACTED]\2", redacted)
+        elif name == "assignment_secret":
+            redacted, count = pattern.subn(lambda m: f"{m.group(1)}=[REDACTED]", redacted)
+        else:
+            redacted, count = pattern.subn("[REDACTED]", redacted)
+        if count:
+            counts[name] = counts.get(name, 0) + count
+    return redacted, counts
+
+
+def redact_value(value: Any) -> tuple[Any, dict[str, Any]]:
+    """Redact nested structures before model, user, or general audit exposure."""
+    if isinstance(value, str):
+        redacted, counts = redact_text(value)
+        return redacted, {"redacted": bool(counts), "counts": counts}
+    if isinstance(value, list):
+        items = []
+        totals: dict[str, int] = {}
+        for item in value:
+            redacted_item, meta = redact_value(item)
+            items.append(redacted_item)
+            for key, count in dict(meta.get("counts", {})).items():
+                totals[key] = totals.get(key, 0) + int(count)
+        return items, {"redacted": bool(totals), "counts": totals}
+    if isinstance(value, dict):
+        obj = {}
+        totals: dict[str, int] = {}
+        for key, item in value.items():
+            redacted_item, meta = redact_value(item)
+            obj[key] = redacted_item
+            for pattern_name, count in dict(meta.get("counts", {})).items():
+                totals[pattern_name] = totals.get(pattern_name, 0) + int(count)
+        return obj, {"redacted": bool(totals), "counts": totals}
+    return value, {"redacted": False, "counts": {}}

--- a/xfusion/security/secrets.py
+++ b/xfusion/security/secrets.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+SECRET_PATH_MARKERS = (
+    "/.ssh/id_rsa",
+    "/.ssh/id_dsa",
+    "/.ssh/id_ecdsa",
+    "/.ssh/id_ed25519",
+    "/.kube/config",
+    "/.aws/credentials",
+    "/.config/gcloud/",
+    "/.azure/",
+    "/secrets/",
+    "/secret/",
+    "/run/secrets/",
+    "/var/run/secrets/",
+)
+
+SECRET_FILENAMES = {
+    ".env",
+    ".env.local",
+    ".env.production",
+    "credentials",
+    "credentials.json",
+    "database.yml",
+    "database.yaml",
+    "db.conf",
+    "db.ini",
+}
+
+
+def is_secret_path(path: str) -> bool:
+    """Return True for deterministic known-secret path classes."""
+    raw = str(path)
+    lowered = raw.lower()
+    if lowered == "/etc/shadow":
+        return True
+    if any(marker in lowered for marker in SECRET_PATH_MARKERS):
+        return True
+
+    name = Path(raw).name.lower()
+    if name in SECRET_FILENAMES:
+        return True
+    if name.endswith((".pem", ".key", ".p12", ".pfx")):
+        return True
+    return "credential" in name or "secret" in name

--- a/xfusion/tools/file.py
+++ b/xfusion/tools/file.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from pathlib import Path
 
 from xfusion.execution.command_runner import CommandRunner
+from xfusion.security.secrets import is_secret_path
 from xfusion.tools.base import ToolOutput
 
 
@@ -42,5 +43,25 @@ class FileTools:
                 "is_dir": target.is_dir(),
                 "size_bytes": stat.st_size,
                 "mtime": stat.st_mtime,
+            },
+        )
+
+    def read_file(self, path: str, max_bytes: int = 4096) -> ToolOutput:
+        """Read a bounded non-secret file snippet."""
+        if is_secret_path(path):
+            return ToolOutput(
+                summary="Refusing to read known secret path.",
+                data={"error": "secret_path"},
+            )
+        target = Path(path)
+        if not target.exists() or not target.is_file():
+            return ToolOutput(summary=f"{path} is not a readable file.", data={"error": "not_file"})
+        data = target.read_text(errors="replace")[: max(0, min(max_bytes, 8192))]
+        return ToolOutput(
+            summary=f"Read bounded snippet from {path}.",
+            data={
+                "path": str(target),
+                "content": data,
+                "truncated": target.stat().st_size > len(data),
             },
         )

--- a/xfusion/tools/process.py
+++ b/xfusion/tools/process.py
@@ -42,13 +42,13 @@ class ProcessTools:
             summary=f"Failed to list processes: {res.stderr}", data={"error": res.stderr}
         )
 
-    def kill(self, pid: int, signal: int = 15, port: int | None = None) -> ToolOutput:
+    def kill(self, pid: int, signal: str = "TERM", port: int | None = None) -> ToolOutput:
         """Send signal to a resolved PID."""
         res = self.runner.run(["kill", f"-{signal}", str(pid)])
         if res.exit_code == 0:
             return ToolOutput(
                 summary=f"Sent signal {signal} to PID {pid}.",
-                data={"pid": pid, "signal": signal, "port": port},
+                data={"ok": True, "pid": pid, "signal": signal, "port": port},
             )
         return ToolOutput(
             summary=f"Failed to kill PID {pid}: {res.stderr}", data={"error": res.stderr}

--- a/xfusion/tools/registry.py
+++ b/xfusion/tools/registry.py
@@ -39,6 +39,7 @@ class ToolRegistry:
             "disk.find_large_directories": disk_tools.find_large_directories,
             "file.search": file_tools.search,
             "file.preview_metadata": file_tools.preview_metadata,
+            "file.read_file": file_tools.read_file,
             "process.list": process_tools.list,
             "process.find_by_port": process_tools.find_by_port,
             "process.kill": process_tools.kill,

--- a/xfusion/tools/system.py
+++ b/xfusion/tools/system.py
@@ -73,7 +73,7 @@ class SystemTools:
         """Report the current effective user."""
         res = self.runner.run(["id", "-un"])
         user = res.stdout.strip() if res.exit_code == 0 else os.environ.get("USER", "unknown")
-        return ToolOutput(summary=f"Current user: {user}", data={"user": user})
+        return ToolOutput(summary=f"Current user: {user}", data={"username": user})
 
     def check_sudo(self) -> ToolOutput:
         """Report whether passwordless sudo is currently available."""

--- a/xfusion/tools/system.py
+++ b/xfusion/tools/system.py
@@ -46,7 +46,7 @@ class SystemTools:
         elif shutil.which("dnf"):
             state.package_manager = "dnf"
 
-        # Disk pressure (simplified for v0.1)
+        # Coarse environment signal used by policy and cleanup planning.
         res = self.runner.run(["df", "/", "--output=pcent"])
         if res.exit_code == 0:
             try:

--- a/xfusion/verification/runner.py
+++ b/xfusion/verification/runner.py
@@ -159,7 +159,8 @@ class FakeWorkflowRegistry:
         if name == "process.kill":
             self.port_occupied = False
             return ToolOutput(
-                summary="Sent signal 15 to PID 4242.", data={"pid": 4242, "signal": 15}
+                summary="Sent TERM to PID 4242.",
+                data={"ok": True, "pid": 4242, "signal": "TERM"},
             )
         return ToolOutput(
             summary=f"Unsupported fake tool {name}.", data={"error": "unsupported_fake_tool"}


### PR DESCRIPTION
## Summary

- introduces the v0.2 capability-governed execution stack
- formalizes XFusion Capability Schema as the authoritative schema contract
- validates capability schemas at registration/startup and keeps unsupported or malformed schemas fail-closed
- archives v0.1 materials under docs/archive/v0.1 with non-normative banners
- aligns active README/CLI/agent guidance with the v0.2 spec

## Validation

- uv run pytest -q
- uv run ruff check .
- uv run ruff format --check .
- uv run ty check

## Resolves

Closes #3
Closes #4

## Notes

XFusion now uses the explicit XFusion Capability Schema contract rather than promising general JSON Schema compatibility. Unsupported schema keywords remain deterministic fail-closed behavior.