### PR TITLE
release(v0.2.4): policy integrity, normalized decisions, and adversarial hardening

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -68,7 +68,9 @@ Start here:
 - [README.md](README.md): short project overview and development commands.
 - [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md): normative v0.2 spec.
 - [docs/architecture/capability-schema.md](docs/architecture/capability-schema.md): XFusion Capability Schema contract.
+- [docs/architecture/execution-policy-v0.2.4.md](docs/architecture/execution-policy-v0.2.4.md): current policy integrity and confirmation semantics.
 - [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md): reviewer notes.
+- [docs/release-plan-v0.2.4.md](docs/release-plan-v0.2.4.md): v0.2.4 release notes and deferred follow-ons.
 - [problem_statement.pdf](problem_statement.pdf): original contest problem statement.
 
 Supporting docs:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,45 @@
 # Changelog
 
+## v0.2.4 - 2026-04-24
+
+- Added normalized machine-readable policy outputs and reason codes:
+  `decision` (`allow|require_confirmation|deny`), `confirmation_type`
+  (`none|user|admin`), `deny_code`, and separate `reason_text`.
+- Added normalized non-execution reason codes/text on steps and audit records
+  (`non_execution.code`, `non_execution.reason_text`) while keeping legacy
+  compatibility fields.
+- Made `high` risk explicit and enforced: destructive/process-control actions
+  now require admin confirmation (`ADMIN_APPROVE ...`), medium risk remains user
+  confirmation, critical stays default deny.
+- Introduced execute-time policy integrity snapshots and hash verification for
+  every step; stale or drifted policy/state now fail closed with
+  `policy_integrity_mismatch`.
+- Hardened approval fingerprint binding with policy snapshot hash and
+  deterministic step binding (plan id, step id/index, dependencies), preventing
+  replay across mutated/reordered plans.
+- Expanded adversarial tests for stale policy metadata, changed risk after
+  approval, changed arguments after confirmation, plan reorder tampering, and
+  normalized audit decision-chain fields.
+
+## v0.2.3 - 2026-04-24
+
+- Added deterministic per-step risk classification and policy-table execution
+  gating on top of the registered capability model.
+- Introduced a normalized risk contract (`risk_level`, confirmation
+  requirement, side effects, reversibility, privilege requirement, deny reason)
+  attached to each planned step before execution.
+- Tightened execution safety so steps cannot run without policy metadata, and
+  confirmation-gated steps fail closed when approval state is missing or
+  invalidated.
+- Extended approval binding so action fingerprints include risk-contract
+  metadata, preventing silent reuse across materially different invocations.
+- Expanded audit records with structured decision trail fields for request,
+  normalized step, risk classification, policy decision, confirmation state, and
+  non-execution reason.
+- Added comprehensive v0.2.3 tests for allow/confirm/deny outcomes, risky
+  pattern fail-closed behavior, confirmation reuse hardening, dependency-safe
+  gating, and audit trail completeness.
+
 ## v0.2.2 - 2026-04-23
 
 - Expanded deterministic verification-repair hardening with explicit

--- a/README.md
+++ b/README.md
@@ -17,8 +17,9 @@ this order:
 
 1. [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md) (normative source of truth)
 2. [docs/architecture/capability-schema.md](docs/architecture/capability-schema.md) (schema contract)
-3. [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) (current reviewer posture)
-4. [docs/review-merge-readiness-v0.2.2.md](docs/review-merge-readiness-v0.2.2.md) (current PR/review artifacts and known follow-ons)
+3. [docs/architecture/execution-policy-v0.2.4.md](docs/architecture/execution-policy-v0.2.4.md) (policy integrity and normalized decision chain)
+4. [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) (current reviewer posture)
+5. [docs/release-plan-v0.2.4.md](docs/release-plan-v0.2.4.md) (v0.2.4 release notes and follow-ons)
 
 ## What It Does
 
@@ -28,6 +29,7 @@ this order:
 - Senses environment facts such as distro, current user, sudo availability,
   systemd availability, package manager, disk pressure, and protected paths.
 - Routes only through registered capabilities, never arbitrary shell passthrough.
+- Classifies each planned step into deterministic allow/confirm/deny policy outcomes.
 - Requires approval-bound exact typed confirmation for mutation capabilities.
 - Refuses forbidden operations on protected paths such as `/`, `/etc`, `/usr`,
   `/boot`, and `/var/lib`.
@@ -85,9 +87,10 @@ Important trust boundary:
 - [xfusion/](xfusion/) - Python package and agent implementation
 - [docs/specs/xfusion-v0.2.md](docs/specs/xfusion-v0.2.md) - normative v0.2 spec
 - [docs/architecture/capability-schema.md](docs/architecture/capability-schema.md) - XFusion Capability Schema contract
+- [docs/architecture/execution-policy-v0.2.4.md](docs/architecture/execution-policy-v0.2.4.md) - v0.2.4 policy integrity and machine-readable decision-chain contract
 - [docs/architecture/schema-subset.md](docs/architecture/schema-subset.md) - quick pointer to the schema subset contract
 - [docs/release-readiness-v0.2.md](docs/release-readiness-v0.2.md) - reviewer notes
-- [docs/review-merge-readiness-v0.2.2.md](docs/review-merge-readiness-v0.2.2.md) - PR summary and reviewer guide
+- [docs/release-plan-v0.2.4.md](docs/release-plan-v0.2.4.md) - v0.2.4 release notes and deferred backlog
 - [docs/verification-suite.md](docs/verification-suite.md) - verification suite design
 - [docs/archive/v0.1/](docs/archive/v0.1/) - historical, non-normative legacy materials
 - [CHANGELOG.md](CHANGELOG.md) - release notes
@@ -181,10 +184,10 @@ the dangerous decisions inspectable and controllable.
 ## Status
 
 v0.2 capability-governed execution is implemented and tested. The current
-hardening baseline is `v0.2.2`, which keeps the v0.2 architecture authoritative
-while tightening repair/equivalence handling, clarifying containment guardrail
-boundaries, and increasing verification corpus depth. The v0.2 spec remains the
-normative source of truth.
+shipping increment is `v0.2.4`, which keeps the v0.2 architecture authoritative
+while adding policy decision normalization, explicit high-risk admin
+confirmation semantics, and execute-time policy integrity binding on registered
+capabilities. The v0.2 spec remains the normative source of truth.
 Legacy materials live only in the historical archive and are explicitly
 non-normative.
 

--- a/docs/architecture/execution-policy-v0.2.3.md
+++ b/docs/architecture/execution-policy-v0.2.3.md
@@ -1,0 +1,87 @@
+# XFusion v0.2.3 Execution Risk Gating
+
+> Superseded by [execution-policy-v0.2.4.md](execution-policy-v0.2.4.md) for
+> the current release baseline.
+
+This document describes the focused v0.2.3 execution-policy increment.
+
+v0.2.3 keeps the existing deterministic registered-capability execution model,
+and adds a stricter risk-aware gating layer before any step can execute.
+
+## Goals
+
+- Keep execution deterministic, fail-closed, and auditable.
+- Preserve the registered capability model (`capability + args`).
+- Classify step risk before execution and enforce explicit policy outcomes.
+
+## Risk Contract
+
+Each planned step is annotated with a normalized risk contract during policy
+processing:
+
+- `risk_level`: `low | medium | high | critical`
+- `requires_confirmation`: `bool`
+- `deny_reason`: optional denial reason string
+- `side_effects`: deterministic side-effect tags
+- `reversibility`: `reversible | partially_reversible | destructive`
+- `privilege_required`: `bool`
+
+Risk contract source of truth:
+
+- [xfusion/policy/risk.py](../../xfusion/policy/risk.py)
+
+## Deterministic Policy Outcomes
+
+v0.2.3 policy still returns exactly one of:
+
+- `allow`
+- `require_confirmation` (step-bound typed confirmation)
+- `deny`
+
+The policy decision remains authoritative and is derived from explicit code
+rules, not model judgment.
+
+## Rule Table Behavior
+
+The v0.2.3 rule table is intentionally compact and explicit:
+
+- Read-only inspection -> allow
+- Bounded cleanup preview (`execute=false`) -> allow
+- Unknown risky argument pattern -> deny (fail-closed)
+- Broad-impact destructive mutation -> deny
+- Network/system-config mutation families (not explicitly enabled) -> deny
+- Destructive/process/privileged/filesystem mutation -> require confirmation
+- Unclassified mutation -> deny (fail-closed)
+
+## Confirmation Binding
+
+Confirmations remain step-aware and exact:
+
+- Approval record is bound to normalized args, provenance, target context,
+  approval mode, risk tier, referenced output fingerprints, and risk contract.
+- Material changes invalidate approval before execution.
+- Confirmation for one step cannot silently apply to a materially different
+  invocation.
+
+## Execution Gate Invariants
+
+Before adapter runtime executes a step:
+
+1. Policy metadata must exist (`policy_rule_id` present).
+2. If confirmation is required, a valid approved record must exist.
+3. Approval fingerprint must still match current invocation.
+
+If any check fails, execution fails closed and no tool is run.
+
+## Audit Trail Additions
+
+v0.2.3 audit events now include structured decision-trail fields per step:
+
+- original user request
+- normalized step (`step_id`, capability, normalized args)
+- risk classification
+- policy decision
+- confirmation required/supplied flags
+- execution or non-execution reason
+
+This preserves reviewer legibility and post-incident explainability.

--- a/docs/architecture/execution-policy-v0.2.4.md
+++ b/docs/architecture/execution-policy-v0.2.4.md
@@ -1,0 +1,95 @@
+# XFusion v0.2.4 Execution Policy Integrity
+
+This document describes the focused v0.2.4 hardening increment on top of v0.2.3.
+
+v0.2.4 keeps the same deterministic, registered-capability execution model and
+adds stronger machine-readable policy normalization plus execute-time integrity
+binding.
+
+## Normalized Policy Fields
+
+Policy and risk metadata now separate machine codes from human text:
+
+- `decision`: `allow | require_confirmation | deny`
+- `confirmation_type`: `none | user | admin`
+- `deny_code`: stable machine-readable denial code
+- `reason_text`: human-readable explanation
+- `non_execution.code`: stable machine-readable non-execution reason
+- `non_execution.reason_text`: human-readable non-execution explanation
+
+The step risk contract also carries normalized fields:
+
+- `risk_level`: `low | medium | high | critical`
+- `requires_confirmation`: `bool`
+- `confirmation_type`: `none | user | admin`
+- `deny_code`: stable code when denied
+- `deny_reason_text`: human-readable deny reason
+
+## Risk Semantics
+
+v0.2.4 enforces deterministic risk semantics:
+
+- `low` -> `allow`
+- `medium` -> `require_confirmation` with `confirmation_type=user`
+- `high` -> `require_confirmation` with `confirmation_type=admin`
+- `critical` -> `deny` (fail-closed default)
+
+`high` is now explicitly enforced (for example destructive/process-control
+mutations), and no longer collapses into `medium` behavior.
+
+## Execute-Time Integrity Layer
+
+Every step now has a deterministic policy snapshot hash bound to:
+
+- capability name
+- normalized args
+- argument provenance
+- policy decision metadata
+- risk contract
+- environment state
+- step binding (`plan_id`, `step_id`, step index, dependencies, repair lineage)
+
+Before execution, policy is always re-evaluated and a new snapshot hash is
+computed. If stored and live hashes differ, execution fails closed with
+`policy_integrity_mismatch` and no tool call is made.
+
+## Approval Binding Hardening
+
+Approval action fingerprints now additionally bind:
+
+- `policy_snapshot_hash`
+- deterministic `step_binding` (including step index and dependencies)
+
+This prevents replay or reuse when plan structure, step identity/order,
+dependencies, policy state, or normalized invocation materially change.
+
+`high` risk approvals use `ADMIN_APPROVE ...` typed confirmation phrases.
+`medium` risk approvals continue to use `APPROVE ...`.
+
+## Multi-Step / Cross-Turn Guarantees
+
+v0.2.4 enforces the following invariants:
+
+1. Policy is rechecked at execute time for every step.
+2. A step approved under one snapshot cannot execute under a changed snapshot.
+3. Step reorder/mutation invalidates previously issued approvals.
+4. Argument/provenance/reference drift invalidates previously issued approvals.
+5. If integrity cannot be proven, execution fails closed.
+
+## Audit Trail Updates
+
+Audit records now include normalized policy and non-execution fields:
+
+- `policy_decision_code`
+- `confirmation_type`
+- `deny_code`
+- `non_execution` object with `code` and `reason_text`
+
+Legacy `non_execution_reason` string remains for compatibility.
+
+## Out of Scope (Unchanged)
+
+- No arbitrary shell passthrough.
+- No broad semantic planner.
+- No capability surface expansion beyond registered tools.
+- No OS/container runtime isolation redesign.

--- a/docs/release-plan-v0.2.3.md
+++ b/docs/release-plan-v0.2.3.md
@@ -1,0 +1,80 @@
+# XFusion v0.2.3 Release Plan
+
+## Release Framing
+
+v0.2.3 is a focused, shippable execution-policy increment for the existing v0.2
+architecture.
+
+Normative source remains:
+
+- [docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md)
+
+Primary objective: add deterministic risk-aware execution gating on top of the
+registered capability model without opening a v0.3 redesign track.
+
+## Implemented Scope
+
+### V023-WS1: Deterministic Risk Classification Contract
+
+- Added deterministic per-step risk classification before execution.
+- Added normalized risk contract fields:
+  - `risk_level` (`low|medium|high|critical`)
+  - `requires_confirmation`
+  - `deny_reason`
+  - `side_effects`
+  - `reversibility`
+  - `privilege_required`
+- Integrated risk metadata into `PolicyDecision` and `PlanStep` audit-visible
+  state.
+
+### V023-WS2: Policy Table For Allow / Confirm / Deny
+
+- Added explicit deterministic policy rule table in
+  [xfusion/policy/risk.py](../xfusion/policy/risk.py).
+- Kept fail-closed defaults for risky unknown patterns and unclassified
+  mutation paths.
+- Preserved protected-path and scope-denial guardrails.
+
+### V023-WS3: Confirmation Gating And Approval Binding Hardening
+
+- Confirmation-gated steps now pause until exact typed confirmation.
+- Approval action fingerprint now includes risk-contract metadata, tightening
+  step-bound approval reuse guarantees.
+- Materially different args/risk profile invalidate approval before execution.
+
+### V023-WS4: Executor Non-Bypass Guardrails
+
+- Execution now refuses steps that bypass policy metadata.
+- If execution is called directly (test/runtime edge), policy is re-evaluated
+  deterministically and fail-closed behavior is enforced.
+- Confirmation-required steps fail closed when approval state is missing or
+  invalid.
+
+### V023-WS5: Structured Audit Decision Trail
+
+- Extended per-step audit records with:
+  - normalized step payload
+  - risk classification
+  - policy decision snapshot
+  - confirmation required/supplied flags
+  - non-execution reason
+
+## Test Coverage Added
+
+- Read-only commands execute without confirmation.
+- Mutations require confirmation with step-bound approval.
+- Unknown risky patterns are denied fail-closed.
+- Confirmation cannot be reused across materially changed commands.
+- Dependency workflows still gate mutation steps safely.
+- Audit output includes policy/risk/confirmation decision trail.
+
+Primary test artifact:
+
+- [tests/test_v023_risk_gating.py](../tests/test_v023_risk_gating.py)
+
+## Deferred To v0.3
+
+- Broader command-family coverage beyond the current registered capability set.
+- Richer policy-table configurability and environment profile overrides.
+- Stronger physical runtime isolation/sandboxing (outside v0.2.3 scope).
+- Expanded verification corpus for additional adversarial policy permutations.

--- a/docs/release-plan-v0.2.4.md
+++ b/docs/release-plan-v0.2.4.md
@@ -1,0 +1,47 @@
+# XFusion v0.2.4 Release Notes
+
+## Summary
+
+v0.2.4 is a focused hardening increment that keeps the v0.2 architecture and
+registered-capability model intact while improving policy integrity and audit
+machine-readability.
+
+## Implemented
+
+- Normalized machine-readable policy outputs (`decision`, `confirmation_type`,
+  `deny_code`) with separate human-readable `reason_text`.
+- Normalized machine-readable non-execution reason codes with human-readable
+  text, propagated into step state and audit records.
+- Explicit `high` risk semantics with admin confirmation path (`ADMIN_APPROVE`
+  typed confirmation phrase).
+- Deterministic execute-time policy integrity checks using per-step policy
+  snapshot hashes.
+- Approval fingerprint hardening with policy snapshot and step-binding data,
+  preventing replay across step/order/dependency/state drift.
+- Adversarial tests for stale snapshots, risk drift, argument mutation,
+  reordered plan tampering, and normalized audit-code output.
+
+## Not Changed (Intentional)
+
+- No arbitrary shell execution.
+- No broad semantic planner.
+- No expansion beyond registered typed capabilities.
+- No physical sandbox/isolation redesign.
+
+## Residual Limitations
+
+- Policy coverage remains compact and capability-family based.
+- Admin confirmation remains typed-confirmation semantics, not identity-backed
+  external auth.
+- Runtime isolation remains declarative and policy-guarded, not OS-level
+  sandboxing.
+
+## Suggested Follow-ons (Post-v0.2.4)
+
+1. Add identity-bound admin confirmation (for example external principal
+   attestation) while preserving deterministic approval fingerprints.
+2. Expand policy-table coverage for more capability families and environment
+   profiles.
+3. Extend adversarial verification scenarios for broader cross-turn/session
+   replay simulations.
+4. Add optional signed audit snapshots for stronger offline tamper evidence.

--- a/docs/release-readiness-v0.2.md
+++ b/docs/release-readiness-v0.2.md
@@ -5,6 +5,15 @@ normative behavior remains [docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md).
 
 ## What Changed
 
+- v0.2.4 keeps deterministic per-step risk classification and adds normalized
+  machine-readable policy outputs (`decision`, `confirmation_type`,
+  `deny_code`) with separate human-readable reasoning text.
+- v0.2.4 makes `high` risk explicit and enforced through admin confirmation
+  semantics, while preserving fail-closed deny behavior for `critical`.
+- v0.2.4 adds execute-time policy integrity snapshots and stronger approval
+  binding against step/order/dependency/state drift.
+- v0.2.4 audit records now include normalized policy/non-execution code fields
+  in addition to human-readable summaries.
 - Execution is capability governed: plans invoke registered `capability + args`
   contracts instead of the legacy `tool + parameters` surface.
 - Static validation rejects unknown capabilities, conflicting legacy fields,
@@ -73,8 +82,21 @@ These are known follow-on hardening areas, not hidden debt:
 - Verification dataset integration is focused on high-value repair/role
   invariants; broader corpus expansion remains a follow-on track.
 
-See [docs/review-merge-readiness-v0.2.2.md](review-merge-readiness-v0.2.2.md)
-for reviewer-facing PR summary, review guide, and follow-on backlog packaging.
+## Deferred Modules (Post-v0.2.4)
+
+These follow-ons are explicitly deferred beyond v0.2.4 and are tracked in the
+v0.2.4 release notes:
+[docs/release-plan-v0.2.4.md](release-plan-v0.2.4.md).
+
+- Broader command-family policy coverage beyond current registered capabilities.
+- More configurable policy tables and environment profile overrides.
+- Physical runtime isolation/sandboxing (outside the v0.2.4 deterministic scope).
+- Additional adversarial verification corpus expansion for policy permutations.
+
+Status: **Post-v0.2.4 Deferred**.
+
+See [docs/release-plan-v0.2.4.md](release-plan-v0.2.4.md) for reviewer-facing
+release packaging and follow-on backlog.
 
 ## Verification Gate
 

--- a/docs/review-merge-readiness-v0.2.3.md
+++ b/docs/review-merge-readiness-v0.2.3.md
@@ -1,0 +1,72 @@
+# XFusion v0.2.3 Review And Merge Readiness
+
+This note packages reviewer-facing artifacts for the v0.2.3 focused execution
+policy increment. Normative behavior remains
+[docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md).
+
+## PR Summary
+
+- Adds deterministic per-step risk classification on top of the existing
+  registered capability execution model.
+- Enforces explicit allow / require_confirmation / deny policy outcomes through
+  a compact code-defined policy table.
+- Keeps approval step-bound and tightens fingerprint binding to include risk
+  contract metadata.
+- Hardens execution so steps cannot run without policy metadata and approved
+  confirmation where required.
+- Extends audit records with a structured decision trail for policy and
+  confirmation outcomes.
+
+## Release Notes (v0.2.3)
+
+- Introduced normalized risk contract fields per step: risk level,
+  confirmation requirement, deny reason, side effects, reversibility, and
+  privilege requirement.
+- Added deterministic risk traits + policy rule table in
+  `xfusion/policy/risk.py` and integrated it into `evaluate_policy`.
+- Added fail-closed handling for unknown risky argument patterns and
+  unclassified mutation paths.
+- Added execution preflight guardrails for missing policy metadata and missing
+  approval state when confirmation is required.
+- Extended audit payloads to include normalized step, risk classification,
+  policy decision snapshot, confirmation state, and non-execution reason.
+
+## How To Review Safely
+
+Review in this order:
+
+1. [docs/specs/xfusion-v0.2.md](specs/xfusion-v0.2.md)
+2. [docs/architecture/execution-policy-v0.2.3.md](architecture/execution-policy-v0.2.3.md)
+3. [xfusion/policy/risk.py](../xfusion/policy/risk.py)
+4. [xfusion/policy/rules.py](../xfusion/policy/rules.py)
+5. [xfusion/graph/nodes/policy.py](../xfusion/graph/nodes/policy.py)
+6. [xfusion/graph/nodes/execute.py](../xfusion/graph/nodes/execute.py)
+7. [xfusion/graph/auditing.py](../xfusion/graph/auditing.py)
+8. [tests/test_v023_risk_gating.py](../tests/test_v023_risk_gating.py)
+
+Review checks to prioritize:
+
+- Risky steps cannot bypass policy evaluation.
+- Confirmation-gated steps do not execute without exact approved binding.
+- Denied actions fail closed and do not run adapters.
+- Unknown risky patterns are denied by default.
+- Audit trail contains policy + confirmation decision artifacts for each step.
+
+## Required Verification Gate
+
+Before merge/release:
+
+```bash
+uv run pytest -q
+uv run ruff check .
+uv run ruff format --check .
+uv run ty check
+```
+
+## Residual Risks (Post-v0.2.3, Explicit)
+
+- Risk policy remains intentionally compact and capability-family based; it is
+  not a broad semantic command analyzer.
+- Capability set is still intentionally limited; network/firewall/package
+  mutation families remain denied unless explicitly introduced later.
+- Runtime containment remains deterministic guardrails, not full OS sandboxing.

--- a/docs/specs/xfusion-v0.2.md
+++ b/docs/specs/xfusion-v0.2.md
@@ -352,7 +352,7 @@ The policy engine is the sole authority that converts a normalized capability
 invocation into:
 
 - `allow`
-- `require_approval`
+- `require_confirmation`
 - `deny`
 
 Policy inputs include:

--- a/docs/verification-dataset-strategy.md
+++ b/docs/verification-dataset-strategy.md
@@ -245,7 +245,7 @@ expected:
 
   policy:
     terminate_process:
-      decision: "require_approval"
+      decision: "require_confirmation"
       risk_tier: 1
 
   approval:
@@ -331,7 +331,7 @@ Recommended dimensions:
 | Dimension            | Values                                                        |
 | -------------------- | ------------------------------------------------------------- |
 | capability class     | Tier 0, Tier 1, Tier 2, Tier 3                                |
-| policy outcome       | allow, require_approval, deny                                 |
+| policy outcome       | allow, require_confirmation, deny                                 |
 | approval state       | none, pending, granted, expired, invalidated, denied          |
 | reference state      | valid, missing, wrong type, unauthorized, stale, forged       |
 | runtime state        | success, timeout, adapter failure, execution failure, blocked |
@@ -465,8 +465,8 @@ Take one valid case and vary a single factor:
 
 Then assert the expected state transition changes appropriately:
 
-* allow → require_approval
-* require_approval → deny
+* allow → require_confirmation
+* require_confirmation → deny
 * success → invalidated approval
 * visible output → redacted output
 * valid reference → blocked reference

--- a/tests/test_smoke.py
+++ b/tests/test_smoke.py
@@ -99,7 +99,7 @@ def test_smoke_confirmation_flow():
     state = graph.invoke(state)
     assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
     phrase = state["pending_confirmation_phrase"]
-    assert phrase.startswith("APPROVE ")
+    assert phrase.startswith(("APPROVE ", "ADMIN_APPROVE "))
 
     # Second turn: user confirms with exact phrase
     state["user_input"] = phrase

--- a/tests/test_v023_risk_gating.py
+++ b/tests/test_v023_risk_gating.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+from xfusion.domain.enums import InteractionState, PolicyDecisionValue
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+from xfusion.graph.nodes.execute import execute_node
+from xfusion.graph.state import AgentGraphState
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.policy.rules import evaluate_policy
+from xfusion.tools.base import ToolOutput
+
+
+class RecordingRegistry:
+    def __init__(self, outputs: dict[str, ToolOutput] | None = None) -> None:
+        self.outputs = outputs or {}
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def execute(self, name: str, args: dict[str, object]) -> ToolOutput:
+        self.calls.append((name, args))
+        return self.outputs.get(name, ToolOutput(summary="ok", data={"ok": True}))
+
+
+def _state_for_plan(plan: ExecutionPlan, *, user_input: str) -> dict[str, object]:
+    return {
+        "user_input": user_input,
+        "environment": EnvironmentState(),
+        "language": "en",
+        "plan": plan,
+        "current_step_id": None,
+        "policy_decision": None,
+        "verification_result": None,
+        "last_tool_output": None,
+        "step_outputs": {},
+        "authorized_step_outputs": {},
+        "pending_confirmation_phrase": None,
+        "response": "",
+        "audit_records": [],
+    }
+
+
+def test_read_only_policy_allows_without_confirmation_and_sets_risk_contract() -> None:
+    decision = evaluate_policy(
+        capability_name="disk.check_usage",
+        resolved_args={"path": "/"},
+        argument_provenance={"path": "literal_or_validated_user_input"},
+        environment=EnvironmentState(),
+    )
+
+    assert decision.decision == PolicyDecisionValue.ALLOW
+    assert decision.risk_contract is not None
+    assert decision.risk_contract.risk_level == "low"
+    assert decision.risk_contract.requires_confirmation is False
+    assert "read_only_inspection" in decision.risk_contract.side_effects
+
+
+def test_mutation_policy_requires_confirmation_and_sets_step_bound_risk_contract() -> None:
+    decision = evaluate_policy(
+        capability_name="user.delete",
+        resolved_args={"username": "demoagent"},
+        argument_provenance={"username": "literal_or_validated_user_input"},
+        environment=EnvironmentState(),
+    )
+
+    assert decision.decision == PolicyDecisionValue.REQUIRE_APPROVAL
+    assert decision.risk_contract is not None
+    assert decision.risk_contract.risk_level == "high"
+    assert decision.confirmation_type == "admin"
+    assert decision.risk_contract.requires_confirmation is True
+    assert decision.risk_contract.confirmation_type == "admin"
+    assert decision.risk_contract.privilege_required is True
+
+
+def test_unknown_risky_pattern_fails_closed_with_clear_reason() -> None:
+    decision = evaluate_policy(
+        capability_name="cleanup.safe_disk_cleanup",
+        resolved_args={
+            "approved_paths": ["/tmp"],
+            "candidate_class": "rm -rf /",
+            "older_than_days": 7,
+            "max_files": 10,
+            "max_bytes": 1000,
+            "execute": True,
+        },
+        argument_provenance={
+            "approved_paths": "literal_or_validated_user_input",
+            "candidate_class": "literal_or_validated_user_input",
+            "older_than_days": "literal_or_validated_user_input",
+            "max_files": "literal_or_validated_user_input",
+            "max_bytes": "literal_or_validated_user_input",
+            "execute": "literal_or_validated_user_input",
+        },
+        environment=EnvironmentState(),
+    )
+
+    assert decision.decision == PolicyDecisionValue.DENY
+    assert decision.risk_contract is not None
+    assert decision.risk_contract.risk_level == "critical"
+    assert decision.risk_contract.deny_reason
+    assert "unknown_risky_pattern" in decision.reason_codes
+
+
+def test_dependency_workflow_respects_confirmation_gate_before_mutation_execution() -> None:
+    registry = RecordingRegistry(
+        outputs={
+            "process.find_by_port": ToolOutput(
+                summary="found",
+                data={"pids": [1234], "stdout": ""},
+            ),
+            "process.kill": ToolOutput(
+                summary="killed",
+                data={"ok": True, "pid": 1234, "signal": "TERM"},
+            ),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v023-dependency-gate",
+        goal="stop process on port",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process first.",
+                on_failure="stop",
+            ),
+            PlanStep(
+                step_id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.find.outputs.pids[0]", "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process after lookup.",
+                on_failure="stop",
+                verification_step_ids=["verify"],
+            ),
+            PlanStep(
+                step_id="verify",
+                capability="process.find_by_port",
+                args={"port": 8080, "expect_free": True},
+                depends_on=["kill"],
+                expected_outputs={"pids": "array"},
+                justification="Verify process is gone.",
+                on_failure="stop",
+            ),
+        ],
+        verification_strategy="verify process stop",
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="stop process on port 8080"))
+
+    # Read-only dependency step executes, mutation step is gated pending confirmation.
+    assert [call[0] for call in registry.calls] == ["process.find_by_port"]
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    assert state["plan"].steps[1].risk_contract["requires_confirmation"] is True
+
+
+def test_confirmation_cannot_be_reused_for_materially_different_args() -> None:
+    registry = RecordingRegistry(
+        outputs={
+            "process.kill": ToolOutput(
+                summary="killed",
+                data={"ok": True, "pid": 1234, "signal": "TERM"},
+            )
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v023-no-reuse",
+        goal="stop process",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="kill",
+                capability="process.kill",
+                args={"pid": 1234, "signal": "TERM"},
+                expected_outputs={"ok": "boolean"},
+                justification="Stop process.",
+                on_failure="stop",
+            )
+        ],
+        verification_strategy="verify process stop",
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="stop pid 1234"))
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    phrase = state["pending_confirmation_phrase"]
+    assert phrase
+
+    # Materially change invocation after approval prompt to ensure approval fingerprint mismatch.
+    state["plan"].steps[0].args = {"pid": 9999, "signal": "TERM"}
+    state["user_input"] = phrase
+    state = graph.invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.FAILED
+    assert state["plan"].steps[0].failure_class == "approval_invalidated"
+    assert state["plan"].steps[0].non_execution_code == "policy_integrity_mismatch"
+    assert registry.calls == []
+
+
+def test_audit_record_contains_risk_policy_confirmation_and_non_execution_fields() -> None:
+    registry = RecordingRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v023-audit",
+        goal="delete protected path",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="cleanup",
+                capability="cleanup.safe_disk_cleanup",
+                args={"approved_paths": ["/etc"], "execute": True},
+                expected_outputs={"ok": "boolean"},
+                justification="Should be denied.",
+                on_failure="stop",
+            )
+        ],
+        verification_strategy="deny protected path mutation",
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="cleanup /etc"))
+    assert state["plan"].interaction_state == InteractionState.REFUSED
+
+    record = next(r for r in state["audit_records"] if r.get("status") == "scope_violation")
+    assert record["original_user_request"]
+    assert record["normalized_step"]["capability"] == "cleanup.safe_disk_cleanup"
+    assert record["risk_classification"]["risk_level"] == "critical"
+    assert record["policy_decision"]["decision"] == "deny"
+    assert record["confirmation_required"] is False
+    assert record["confirmation_supplied"] is False
+    assert record["non_execution_reason"] == "scope_violation"
+
+
+def test_execute_precheck_denial_sets_refused_plan_state_and_skips_runtime() -> None:
+    registry = RecordingRegistry()
+    plan = ExecutionPlan(
+        plan_id="v023-execute-precheck-deny",
+        goal="attempt protected cleanup",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="cleanup",
+                capability="cleanup.safe_disk_cleanup",
+                args={"approved_paths": ["/etc"], "execute": True},
+                expected_outputs={"ok": "boolean"},
+                justification="Should be denied by policy precheck.",
+                on_failure="stop",
+            )
+        ],
+        verification_strategy="deny protected path mutation",
+    )
+    state = AgentGraphState.model_validate(_state_for_plan(plan, user_input="cleanup /etc"))
+
+    result = execute_node(state, registry=registry)
+
+    assert result.plan is not None
+    assert result.plan.interaction_state == InteractionState.REFUSED
+    assert result.plan.status == "refused"
+    assert result.plan.steps[0].status == "refused"
+    assert result.plan.steps[0].failure_class == "policy_denial"
+    assert registry.calls == []

--- a/tests/test_v024_policy_integrity.py
+++ b/tests/test_v024_policy_integrity.py
@@ -1,0 +1,215 @@
+from __future__ import annotations
+
+from xfusion.domain.enums import InteractionState, PolicyDecisionValue
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.domain.models.execution_plan import ExecutionPlan, PlanStep
+from xfusion.graph.nodes.execute import execute_node
+from xfusion.graph.state import AgentGraphState
+from xfusion.graph.wiring import build_agent_graph
+from xfusion.policy.rules import evaluate_policy
+from xfusion.tools.base import ToolOutput
+
+
+class RecordingRegistry:
+    def __init__(self, outputs: dict[str, ToolOutput] | None = None) -> None:
+        self.outputs = outputs or {}
+        self.calls: list[tuple[str, dict[str, object]]] = []
+
+    def execute(self, name: str, args: dict[str, object]) -> ToolOutput:
+        self.calls.append((name, args))
+        return self.outputs.get(name, ToolOutput(summary="ok", data={"ok": True}))
+
+
+def _state_for_plan(plan: ExecutionPlan, *, user_input: str) -> dict[str, object]:
+    return {
+        "user_input": user_input,
+        "environment": EnvironmentState(),
+        "language": "en",
+        "plan": plan,
+        "current_step_id": None,
+        "policy_decision": None,
+        "verification_result": None,
+        "last_tool_output": None,
+        "step_outputs": {},
+        "authorized_step_outputs": {},
+        "pending_confirmation_phrase": None,
+        "response": "",
+        "audit_records": [],
+    }
+
+
+def test_high_risk_requires_admin_confirmation() -> None:
+    decision = evaluate_policy(
+        capability_name="process.kill",
+        resolved_args={"pid": 1234, "signal": "TERM"},
+        argument_provenance={
+            "pid": "literal_or_validated_user_input",
+            "signal": "literal_or_validated_user_input",
+        },
+        environment=EnvironmentState(),
+    )
+
+    assert decision.decision == PolicyDecisionValue.REQUIRE_CONFIRMATION
+    assert decision.risk_contract is not None
+    assert decision.risk_contract.risk_level == "high"
+    assert decision.confirmation_type == "admin"
+    assert decision.risk_contract.confirmation_type == "admin"
+
+
+def test_execute_fails_closed_on_stale_policy_snapshot_hash() -> None:
+    registry = RecordingRegistry()
+    plan = ExecutionPlan(
+        plan_id="v024-stale-snapshot",
+        goal="read disk usage",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="check",
+                capability="disk.check_usage",
+                args={"path": "/"},
+                expected_outputs={"usage": "string"},
+                justification="Read disk usage.",
+                on_failure="stop",
+                policy_snapshot_hash="stale_snapshot_hash",
+            )
+        ],
+    )
+
+    state = AgentGraphState.model_validate(_state_for_plan(plan, user_input="check disk"))
+    result = execute_node(state, registry=registry)
+
+    assert result.plan is not None
+    assert result.plan.steps[0].failure_class == "approval_invalidated"
+    assert result.plan.steps[0].non_execution_code == "policy_integrity_mismatch"
+    assert registry.calls == []
+
+
+def test_changed_risk_after_approval_is_blocked_before_execution() -> None:
+    registry = RecordingRegistry(
+        outputs={
+            "user.create": ToolOutput(summary="created", data={"exists": True}),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v024-risk-drift",
+        goal="write file",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="create_user",
+                capability="user.create",
+                args={"username": "demo-user"},
+                expected_outputs={"exists": "boolean"},
+                justification="Create bounded demo user.",
+                on_failure="stop",
+            )
+        ],
+        verification_strategy="verify policy-integrity gate",
+        verification_no_meaningful_verifier=True,
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="create demo user"))
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    phrase = state["pending_confirmation_phrase"]
+    assert phrase
+
+    # Escalate to a destructive admin-risk action after approval prompt.
+    state["plan"].steps[0].capability = "user.delete"
+    state["plan"].steps[0].args = {"username": "demo-user"}
+    state["user_input"] = phrase
+    state = graph.invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.FAILED
+    assert state["plan"].steps[0].failure_class == "approval_invalidated"
+    assert state["plan"].steps[0].non_execution_code == "policy_integrity_mismatch"
+    assert registry.calls == []
+
+
+def test_reordered_multistep_plan_invalidates_existing_approval() -> None:
+    registry = RecordingRegistry(
+        outputs={
+            "process.find_by_port": ToolOutput(summary="found", data={"pids": [1234]}),
+            "process.kill": ToolOutput(summary="killed", data={"ok": True}),
+        }
+    )
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v024-plan-reorder",
+        goal="find and kill process",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="find",
+                capability="process.find_by_port",
+                args={"port": 8080},
+                expected_outputs={"pids": "array"},
+                justification="Find process first.",
+                on_failure="stop",
+            ),
+            PlanStep(
+                step_id="kill",
+                capability="process.kill",
+                args={"pid": "$steps.find.outputs.pids[0]", "signal": "TERM"},
+                depends_on=["find"],
+                expected_outputs={"ok": "boolean"},
+                justification="Kill after lookup.",
+                on_failure="stop",
+                verification_step_ids=["verify"],
+            ),
+            PlanStep(
+                step_id="verify",
+                capability="process.find_by_port",
+                args={"port": 8080, "expect_free": True},
+                depends_on=["kill"],
+                expected_outputs={"pids": "array"},
+                justification="Verify process is gone.",
+                on_failure="stop",
+            ),
+        ],
+        verification_strategy="verify process stop",
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="kill process on 8080"))
+    assert state["plan"].interaction_state == InteractionState.AWAITING_CONFIRMATION
+    phrase = state["pending_confirmation_phrase"]
+    assert phrase
+
+    # Reorder pending step position after approval was requested.
+    state["plan"].steps = [state["plan"].steps[1], state["plan"].steps[0]]
+    state["user_input"] = phrase
+    state = graph.invoke(state)
+
+    assert state["plan"].interaction_state == InteractionState.FAILED
+    assert state["plan"].steps[0].failure_class == "approval_invalidated"
+    assert state["plan"].steps[0].non_execution_code == "policy_integrity_mismatch"
+    assert [call[0] for call in registry.calls] == ["process.find_by_port"]
+
+
+def test_audit_record_emits_normalized_machine_codes() -> None:
+    registry = RecordingRegistry()
+    graph = build_agent_graph(registry).compile()
+    plan = ExecutionPlan(
+        plan_id="v024-audit-codes",
+        goal="attempt protected cleanup",
+        language="en",
+        steps=[
+            PlanStep(
+                step_id="cleanup",
+                capability="cleanup.safe_disk_cleanup",
+                args={"approved_paths": ["/etc"], "execute": True},
+                expected_outputs={"ok": "boolean"},
+                justification="Should be denied.",
+                on_failure="stop",
+            )
+        ],
+        verification_strategy="deny protected path mutation",
+    )
+
+    state = graph.invoke(_state_for_plan(plan, user_input="cleanup /etc"))
+    record = next(r for r in state["audit_records"] if r.get("status") == "scope_violation")
+
+    assert record["policy_decision_code"] == "deny"
+    assert record["confirmation_type"] == "none"
+    assert record["deny_code"] == "protected_path"
+    assert record["non_execution"]["code"] in {"protected_path", "scope_violation"}

--- a/tests/test_v02_contracts.py
+++ b/tests/test_v02_contracts.py
@@ -366,7 +366,7 @@ def test_legacy_ref_dict_is_blocked_before_approval_or_execution() -> None:
     )
 
 
-def test_policy_uses_v02_allow_require_approval_deny_decisions() -> None:
+def test_policy_uses_v02_allow_require_confirmation_deny_decisions() -> None:
     allowed = evaluate_policy(
         capability_name="system.service_status",
         resolved_args={"service": "nginx"},

--- a/tests/verification_dataset/scenarios/repair_role_hardening.yaml
+++ b/tests/verification_dataset/scenarios/repair_role_hardening.yaml
@@ -54,7 +54,7 @@
       required_capabilities: [process.kill]
     policy:
       process.kill:
-        decision: require_approval
+        decision: require_confirmation
         risk_tier: 1
     approval:
       required: true
@@ -89,7 +89,7 @@
       required_capabilities: [process.kill]
     policy:
       process.kill:
-        decision: require_approval
+        decision: require_confirmation
         risk_tier: 1
     approval:
       required: true
@@ -125,7 +125,7 @@
       required_capabilities: [process.kill]
     policy:
       process.kill:
-        decision: require_approval
+        decision: require_confirmation
         risk_tier: 1
     approval:
       required: true

--- a/tests/verification_dataset/schema/case-schema.yaml
+++ b/tests/verification_dataset/schema/case-schema.yaml
@@ -24,7 +24,7 @@ expected:
 
   policy:
     "<capability_name>":
-      decision: "string" # allow, require_approval, deny
+      decision: "string" # allow, require_confirmation, deny
       risk_tier: number
 
   approval:

--- a/verification/scenarios/gold_demo.yaml
+++ b/verification/scenarios/gold_demo.yaml
@@ -163,7 +163,7 @@
       - "cleanup.safe_disk_cleanup"
       - "disk.check_usage"
     executed_tools: []
-    risk_level: medium
+    risk_level: high
     interaction_state: awaiting_confirmation
     requires_confirmation: true
     verification_method: state_re_read

--- a/verification/scenarios/regression.yaml
+++ b/verification/scenarios/regression.yaml
@@ -115,7 +115,7 @@
     plan_length: 1
     plan_tools: ["user.delete"]
     executed_tools: []
-    risk_level: medium
+    risk_level: high
     interaction_state: awaiting_confirmation
     requires_confirmation: true
     verification_method: existence_nonexistence_check
@@ -136,7 +136,7 @@
     plan_length: 3
     plan_tools: ["process.find_by_port", "process.kill", "process.find_by_port"]
     executed_tools: []
-    risk_level: medium
+    risk_level: high
     interaction_state: awaiting_confirmation
     requires_confirmation: true
     verification_method: port_process_recheck

--- a/xfusion/app/cli.py
+++ b/xfusion/app/cli.py
@@ -28,7 +28,7 @@ def main() -> None:
 
     graph = build_agent_graph(registry).compile()
 
-    print("XFusion Guardian v0.2.2")
+    print("XFusion Guardian v0.2.4")
     print("Capability-governed Linux Administration Agent")
     print("Normative spec: docs/specs/xfusion-v0.2.md")
     print("Reviewer notes: docs/release-readiness-v0.2.md")

--- a/xfusion/domain/enums.py
+++ b/xfusion/domain/enums.py
@@ -46,7 +46,9 @@ class ApprovalMode(StrEnum):
 
 class PolicyDecisionValue(StrEnum):
     ALLOW = "allow"
-    REQUIRE_APPROVAL = "require_approval"
+    REQUIRE_CONFIRMATION = "require_confirmation"
+    # Backward-compatible alias; normalized value is require_confirmation.
+    REQUIRE_APPROVAL = "require_confirmation"
     DENY = "deny"
 
 

--- a/xfusion/domain/models/approval.py
+++ b/xfusion/domain/models/approval.py
@@ -36,6 +36,7 @@ class ApprovalRecord(BaseModel):
     normalized_capability_set: list[str] = Field(min_length=1)
     target_context: dict[str, Any]
     action_fingerprint: str = Field(min_length=1)
+    policy_snapshot_hash: str = Field(min_length=1)
     referenced_output_fingerprints: dict[str, str] = Field(default_factory=dict)
     approval_mode: ApprovalMode
     risk_tier: RiskTier

--- a/xfusion/domain/models/execution_plan.py
+++ b/xfusion/domain/models/execution_plan.py
@@ -30,9 +30,15 @@ class PlanStep(BaseModel):
     resolved_references: dict[str, object] = Field(default_factory=dict)
     adapter_id: str | None = None
     policy_rule_id: str | None = None
+    policy_snapshot_hash: str | None = None
+    policy_snapshot: dict[str, object] = Field(default_factory=dict)
     approval_mode: ApprovalMode | None = None
+    risk_contract: dict[str, object] = Field(default_factory=dict)
+    confirmation_supplied: bool | None = None
     authorized_output_accepted: bool = False
     failure_class: str | None = None
+    non_execution_code: str | None = None
+    non_execution_reason_text: str | None = None
     failure_details: dict[str, object] = Field(default_factory=dict)
     redaction_metadata: dict[str, object] = Field(default_factory=dict)
     started_at: str | None = None

--- a/xfusion/domain/models/policy.py
+++ b/xfusion/domain/models/policy.py
@@ -7,6 +7,23 @@ from pydantic import BaseModel, ConfigDict, Field
 from xfusion.domain.enums import ApprovalMode, PolicyDecisionValue, RiskLevel, RiskTier
 
 
+class StepRiskContract(BaseModel):
+    """Normalized deterministic risk contract for one capability invocation."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    risk_level: str = Field(pattern="^(low|medium|high|critical)$")
+    requires_confirmation: bool
+    confirmation_type: str = Field(pattern="^(none|user|admin)$")
+    deny_code: str | None = None
+    deny_reason_text: str | None = None
+    # Deprecated but retained for compatibility with existing tests/consumers.
+    deny_reason: str | None = None
+    side_effects: list[str] = Field(default_factory=list)
+    reversibility: str = Field(pattern="^(reversible|partially_reversible|destructive)$")
+    privilege_required: bool
+
+
 class PolicyDecision(BaseModel):
     """Authoritative v0.2 policy result for one normalized capability invocation."""
 
@@ -18,8 +35,13 @@ class PolicyDecision(BaseModel):
     approval_mode: ApprovalMode
     constraints_applied: list[str] = Field(default_factory=list)
     reason_codes: list[str] = Field(default_factory=list)
+    confirmation_type: str = Field(pattern="^(none|user|admin)$")
+    deny_code: str | None = None
     explainability_record: dict[str, Any] = Field(default_factory=dict)
+    reason_text: str = Field(min_length=1)
+    # Deprecated but retained for compatibility.
     reason: str = Field(min_length=1)
+    risk_contract: StepRiskContract | None = None
 
     @property
     def is_allowed(self) -> bool:
@@ -27,7 +49,7 @@ class PolicyDecision(BaseModel):
 
     @property
     def requires_approval(self) -> bool:
-        return self.decision == PolicyDecisionValue.REQUIRE_APPROVAL
+        return self.decision == PolicyDecisionValue.REQUIRE_CONFIRMATION
 
     @property
     def is_denied(self) -> bool:
@@ -36,6 +58,13 @@ class PolicyDecision(BaseModel):
     @property
     def risk_level(self) -> RiskLevel:
         """Derived convenience mapping used by graph flow and tests."""
+        if self.risk_contract:
+            return {
+                "low": RiskLevel.LOW,
+                "medium": RiskLevel.MEDIUM,
+                "high": RiskLevel.HIGH,
+                "critical": RiskLevel.FORBIDDEN,
+            }[self.risk_contract.risk_level]
         return {
             RiskTier.TIER_0: RiskLevel.LOW,
             RiskTier.TIER_1: RiskLevel.MEDIUM,

--- a/xfusion/graph/auditing.py
+++ b/xfusion/graph/auditing.py
@@ -4,6 +4,7 @@ from datetime import datetime
 
 from xfusion.audit.jsonl_sink import JsonlAuditSink
 from xfusion.audit.logger import AuditLogger
+from xfusion.domain.enums import ApprovalMode
 from xfusion.domain.models.execution_plan import PlanStep
 from xfusion.graph.state import AgentGraphState
 from xfusion.security.redaction import redact_value
@@ -79,6 +80,20 @@ def log_graph_event(
     redacted_verification, verification_redaction = _safe_redact(verification)
     normalized_output = state.step_outputs.get(step.step_id, {})
     redacted_output, output_redaction = _safe_redact(normalized_output)
+    risk_contract, risk_contract_redaction = _safe_redact(step.risk_contract)
+    policy_decision, policy_decision_redaction = _safe_redact(
+        state.policy_decision.model_dump(mode="json") if state.policy_decision else {}
+    )
+    approval = state.approval_records.get(step.approval_id or "")
+    confirmation_required = bool(
+        step.requires_confirmation or step.approval_mode in {ApprovalMode.HUMAN, ApprovalMode.ADMIN}
+    )
+    confirmation_supplied = bool(approval and approval.is_approved)
+    normalized_step = {
+        "step_id": step.step_id,
+        "capability": step.capability,
+        "normalized_args": step.normalized_args or step.args,
+    }
 
     record = {
         "timestamp": datetime.now().isoformat(),
@@ -91,8 +106,20 @@ def log_graph_event(
         "validation_result": state.validation_result.model_dump(mode="json")
         if state.validation_result
         else None,
+        "normalized_step": normalized_step,
         "step_id": step.step_id,
         "capability": step.capability,
+        "risk_classification": risk_contract,
+        "policy_decision": policy_decision,
+        "policy_decision_code": state.policy_decision.decision.value
+        if state.policy_decision
+        else None,
+        "confirmation_type": (
+            state.policy_decision.confirmation_type if state.policy_decision else "none"
+        ),
+        "deny_code": state.policy_decision.deny_code if state.policy_decision else None,
+        "confirmation_required": confirmation_required,
+        "confirmation_supplied": confirmation_supplied,
         "normalized_args": normalized_args,
         "argument_provenance": step.argument_provenance,
         "resolved_references": step.resolved_references,
@@ -112,10 +139,21 @@ def log_graph_event(
         "verification_result": redacted_verification,
         "repair_proposals": repair_proposals,
         "normalized_output": redacted_output,
+        "non_execution_reason": step.failure_class if step.status != "success" else None,
+        "non_execution": (
+            {
+                "code": step.non_execution_code or step.failure_class,
+                "reason_text": step.non_execution_reason_text,
+            }
+            if step.status != "success"
+            else None
+        ),
         "redaction_metadata": {
             "action": action_redaction,
             "verification": verification_redaction,
             "output": output_redaction,
+            "risk_classification": risk_contract_redaction,
+            "policy_decision": policy_decision_redaction,
             "original_user_request": request_redaction,
             "interpreted_intent": intent_redaction,
             "role_contracts": role_contracts_redaction,

--- a/xfusion/graph/nodes/confirm.py
+++ b/xfusion/graph/nodes/confirm.py
@@ -19,11 +19,13 @@ def confirm_node(state: AgentGraphState) -> AgentGraphState:
     expected = (step.confirmation_phrase or "").strip()
     actual = state.user_input.strip()
     approval = state.approval_records.get(state.pending_approval_id or step.approval_id or "")
-
     if expected and approval and actual == expected and not approval.is_expired():
         approval.approved_at = datetime.now(UTC)
         state.plan.interaction_state = InteractionState.EXECUTING
         step.requires_confirmation = False
+        step.confirmation_supplied = True
+        step.non_execution_code = None
+        step.non_execution_reason_text = None
         state.response = "Confirmation received. Proceeding..."
         log_graph_event(
             state,
@@ -35,18 +37,23 @@ def confirm_node(state: AgentGraphState) -> AgentGraphState:
     else:
         state.plan.interaction_state = InteractionState.ABORTED
         state.plan.status = "aborted"
+        step.confirmation_supplied = False
         reason = "approval_expired" if approval and approval.is_expired() else "phrase_mismatch"
         step.failure_class = (
             FailureClass.APPROVAL_EXPIRED.value
             if reason == "approval_expired"
             else FailureClass.APPROVAL_DENIED.value
         )
+        step.non_execution_code = reason
+        step.non_execution_reason_text = f"Action aborted: approval failed ({reason})."
         step.failure_details = {
             "failure_class": step.failure_class,
+            "non_execution_code": step.non_execution_code,
+            "non_execution_reason_text": step.non_execution_reason_text,
             "approval_id": approval.approval_id if approval else None,
             "reason": reason,
         }
-        state.response = f"Action aborted: approval failed ({reason})."
+        state.response = step.non_execution_reason_text
         if approval:
             approval.invalidated_at = datetime.now(UTC)
             approval.invalidation_reason = reason

--- a/xfusion/graph/nodes/execute.py
+++ b/xfusion/graph/nodes/execute.py
@@ -8,9 +8,38 @@ from xfusion.planning.reference_resolver import resolve_args
 from xfusion.policy.approval import (
     build_argument_provenance,
     build_referenced_output_fingerprints,
+    build_step_binding,
     validate_approval_for_invocation,
 )
-from xfusion.policy.rules import evaluate_policy
+from xfusion.policy.rules import (
+    build_policy_snapshot_hash,
+    build_policy_snapshot_payload,
+    evaluate_policy,
+)
+
+
+def _fail_non_execution(
+    state: AgentGraphState,
+    *,
+    step,
+    status: StepStatus,
+    failure_class: str,
+    code: str,
+    reason_text: str,
+    details: dict[str, object] | None = None,
+) -> AgentGraphState:
+    step.status = status
+    step.failure_class = failure_class
+    step.non_execution_code = code
+    step.non_execution_reason_text = reason_text
+    step.failure_details = {
+        "failure_class": failure_class,
+        "non_execution_code": code,
+        "non_execution_reason_text": reason_text,
+        **(details or {}),
+    }
+    state.response = reason_text
+    return state
 
 
 def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
@@ -31,6 +60,8 @@ def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
 
     step.status = StepStatus.RUNNING
     step.failure_class = None
+    step.non_execution_code = None
+    step.non_execution_reason_text = None
     step.failure_details = {}
     step.authorized_output_accepted = False
     state.step_outputs.pop(step.step_id, None)
@@ -47,29 +78,131 @@ def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
             authorized_outputs=state.authorized_step_outputs,
         )
     except ValueError as e:
-        step.status = StepStatus.FAILED
-        step.failure_class = "reference_resolution_failed"
-        step.failure_details = {
-            "failure_class": "reference_resolution_failed",
-            "capability": step.capability,
-            "args": step.args,
-            "error": str(e),
-        }
-        state.response = f"Parameter resolution failed: {e}"
-        return state
+        return _fail_non_execution(
+            state,
+            step=step,
+            status=StepStatus.FAILED,
+            failure_class="reference_resolution_failed",
+            code="reference_resolution_failed",
+            reason_text=f"Parameter resolution failed: {e}",
+            details={
+                "capability": step.capability,
+                "args": step.args,
+                "error": str(e),
+            },
+        )
+
+    provenance = build_argument_provenance(step.args)
+    step_binding = build_step_binding(state.plan, step)
+
+    policy_recheck = evaluate_policy(
+        capability_name=str(step.capability),
+        resolved_args=resolved_params,
+        argument_provenance=provenance,
+        environment=state.environment,
+        actor_type="assistant",
+        host_class="production",
+        target_scope="explicit",
+        request_intent=state.plan.intent_class,
+        prior_approval_state={
+            approval_id: record.model_dump(mode="json")
+            for approval_id, record in state.approval_records.items()
+        },
+    )
+    state.policy_decision = policy_recheck
+    live_policy_snapshot = build_policy_snapshot_payload(
+        capability_name=str(step.capability),
+        normalized_args=resolved_params,
+        argument_provenance=provenance,
+        decision=policy_recheck,
+        environment=state.environment,
+        step_binding=step_binding,
+    )
+    live_policy_snapshot_hash = build_policy_snapshot_hash(live_policy_snapshot)
+
+    if step.policy_snapshot_hash and step.policy_snapshot_hash != live_policy_snapshot_hash:
+        return _fail_non_execution(
+            state,
+            step=step,
+            status=StepStatus.FAILED,
+            failure_class="approval_invalidated",
+            code="policy_integrity_mismatch",
+            reason_text=(
+                "Execution blocked: policy integrity check failed due to stale or changed state."
+            ),
+            details={
+                "stored_policy_snapshot_hash": step.policy_snapshot_hash,
+                "live_policy_snapshot_hash": live_policy_snapshot_hash,
+                "policy_decision": policy_recheck.model_dump(),
+            },
+        )
+
+    step.policy_snapshot = live_policy_snapshot
+    step.policy_snapshot_hash = live_policy_snapshot_hash
+    step.policy_rule_id = policy_recheck.matched_rule_id
+    step.approval_mode = policy_recheck.approval_mode
+    step.risk_level = policy_recheck.risk_level
+    step.risk_contract = (
+        policy_recheck.risk_contract.model_dump() if policy_recheck.risk_contract else {}
+    )
+    step.requires_confirmation = policy_recheck.requires_approval
+
+    if policy_recheck.decision == PolicyDecisionValue.DENY:
+        state.plan.interaction_state = InteractionState.REFUSED
+        state.plan.status = "refused"
+        return _fail_non_execution(
+            state,
+            step=step,
+            status=StepStatus.REFUSED,
+            failure_class="policy_denial",
+            code=policy_recheck.deny_code or "policy_denial",
+            reason_text=f"Step execution blocked by policy: {policy_recheck.reason_text}",
+            details={"policy_decision": policy_recheck.model_dump()},
+        )
+
+    if policy_recheck.decision == PolicyDecisionValue.REQUIRE_CONFIRMATION and not step.approval_id:
+        return _fail_non_execution(
+            state,
+            step=step,
+            status=StepStatus.FAILED,
+            failure_class="approval_missing",
+            code="confirmation_required_without_approval",
+            reason_text="Step execution blocked: explicit confirmation is required first.",
+            details={"policy_decision": policy_recheck.model_dump()},
+        )
 
     if step.approval_id:
         approval = state.approval_records.get(step.approval_id)
         if approval is None:
-            step.status = StepStatus.FAILED
-            step.failure_class = "approval_missing"
-            step.failure_details = {
-                "failure_class": "approval_missing",
-                "approval_id": step.approval_id,
-                "capability": step.capability,
-            }
-            state.response = "Approval required but no approval record exists."
-            return state
+            return _fail_non_execution(
+                state,
+                step=step,
+                status=StepStatus.FAILED,
+                failure_class="approval_missing",
+                code="approval_record_missing",
+                reason_text="Approval required but no approval record exists.",
+                details={
+                    "approval_id": step.approval_id,
+                    "capability": step.capability,
+                },
+            )
+        if policy_recheck.decision != PolicyDecisionValue.REQUIRE_CONFIRMATION:
+            return _fail_non_execution(
+                state,
+                step=step,
+                status=StepStatus.FAILED,
+                failure_class="approval_invalidated",
+                code="policy_decision_changed",
+                reason_text=(
+                    "Approval invalidated before execution: policy decision changed after approval."
+                ),
+                details={
+                    "approval_id": approval.approval_id,
+                    "capability": step.capability,
+                    "normalized_args": resolved_params,
+                    "policy_decision": policy_recheck.model_dump(),
+                },
+            )
         is_valid, reason = validate_approval_for_invocation(
             approval=approval,
             capability=capability,
@@ -77,57 +210,42 @@ def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
             target_context=state.plan.target_context,
             approval_mode=approval.approval_mode,
             risk_tier=approval.risk_tier,
-            argument_provenance=build_argument_provenance(step.args),
+            risk_contract=step.risk_contract,
+            policy_snapshot_hash=live_policy_snapshot_hash,
+            step_binding=step_binding,
+            argument_provenance=provenance,
             referenced_output_fingerprints=build_referenced_output_fingerprints(
                 step.args, state.authorized_step_outputs
             ),
         )
         if not is_valid:
-            step.status = StepStatus.FAILED
-            step.failure_class = (
-                "approval_invalidated"
-                if reason in {"action_fingerprint_mismatch", "material_change"}
-                else reason
+            return _fail_non_execution(
+                state,
+                step=step,
+                status=StepStatus.FAILED,
+                failure_class="approval_invalidated",
+                code=reason,
+                reason_text=f"Approval invalidated before execution: {reason}",
+                details={
+                    "reason": reason,
+                    "approval_id": approval.approval_id,
+                    "capability": step.capability,
+                    "normalized_args": resolved_params,
+                },
             )
-            step.failure_details = {
-                "failure_class": step.failure_class,
-                "reason": reason,
-                "approval_id": approval.approval_id,
+    elif step.requires_confirmation:
+        return _fail_non_execution(
+            state,
+            step=step,
+            status=StepStatus.FAILED,
+            failure_class="approval_missing",
+            code="requires_confirmation_without_approval_record",
+            reason_text="Approval required but no approval record exists.",
+            details={
                 "capability": step.capability,
-                "normalized_args": resolved_params,
-            }
-            state.response = f"Approval invalidated before execution: {reason}"
-            return state
-
-        policy_recheck = evaluate_policy(
-            capability_name=str(step.capability),
-            resolved_args=resolved_params,
-            argument_provenance=build_argument_provenance(step.args),
-            environment=state.environment,
-            actor_type="assistant",
-            host_class="production",
-            target_scope="explicit",
-            request_intent=state.plan.intent_class,
-            prior_approval_state={
-                approval_id: record.model_dump(mode="json")
-                for approval_id, record in state.approval_records.items()
+                "step_id": step.step_id,
             },
         )
-        if policy_recheck.decision != PolicyDecisionValue.REQUIRE_APPROVAL:
-            step.status = StepStatus.FAILED
-            step.failure_class = "approval_invalidated"
-            step.failure_details = {
-                "failure_class": "approval_invalidated",
-                "reason": "policy_decision_changed",
-                "approval_id": approval.approval_id,
-                "capability": step.capability,
-                "normalized_args": resolved_params,
-                "policy_decision": policy_recheck.model_dump(),
-            }
-            state.response = (
-                "Approval invalidated before execution: policy decision changed after approval."
-            )
-            return state
 
     outcome = ControlledAdapterRuntime(registry).execute(
         capability=capability,
@@ -143,6 +261,8 @@ def execute_node(state: AgentGraphState, registry=None) -> AgentGraphState:
     if outcome.status != "succeeded" or "error" in outcome.normalized_output:
         step.status = StepStatus.FAILED
         step.failure_class = outcome.status
+        step.non_execution_code = outcome.status
+        step.non_execution_reason_text = outcome.summary
         step.failure_details = outcome.normalized_output
         state.last_tool_output = None
         state.response = f"Step failed: {outcome.summary}"

--- a/xfusion/graph/nodes/policy.py
+++ b/xfusion/graph/nodes/policy.py
@@ -8,9 +8,14 @@ from xfusion.graph.state import AgentGraphState
 from xfusion.planning.reference_resolver import resolve_args
 from xfusion.policy.approval import (
     build_argument_provenance,
+    build_step_binding,
     create_approval_record,
 )
-from xfusion.policy.rules import evaluate_policy
+from xfusion.policy.rules import (
+    build_policy_snapshot_hash,
+    build_policy_snapshot_payload,
+    evaluate_policy,
+)
 
 
 def policy_node(state: AgentGraphState) -> AgentGraphState:
@@ -94,6 +99,20 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
     step.requires_confirmation = decision.requires_approval
     step.policy_rule_id = decision.matched_rule_id
     step.approval_mode = decision.approval_mode
+    step.risk_contract = decision.risk_contract.model_dump() if decision.risk_contract else {}
+    step_binding = build_step_binding(state.plan, step)
+    policy_snapshot = build_policy_snapshot_payload(
+        capability_name=str(step.capability),
+        normalized_args=resolved_args,
+        argument_provenance=provenance,
+        decision=decision,
+        environment=state.environment,
+        step_binding=step_binding,
+    )
+    step.policy_snapshot = policy_snapshot
+    step.policy_snapshot_hash = build_policy_snapshot_hash(policy_snapshot)
+    step.non_execution_code = None
+    step.non_execution_reason_text = None
 
     if decision.decision == PolicyDecisionValue.DENY:
         step.status = StepStatus.REFUSED
@@ -102,13 +121,17 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
             if {"scope_violation", "scope_not_explicit"} & set(decision.reason_codes)
             else "policy_denial"
         )
+        step.non_execution_code = decision.deny_code or step.failure_class
+        step.non_execution_reason_text = decision.reason_text
         step.failure_details = {
             "failure_class": step.failure_class,
+            "non_execution_code": step.non_execution_code,
+            "non_execution_reason_text": step.non_execution_reason_text,
             "policy_decision": decision.model_dump(),
         }
         state.plan.interaction_state = InteractionState.REFUSED
         state.plan.status = "refused"
-        state.response = f"I cannot execute this step: {decision.reason}"
+        state.response = f"I cannot execute this step: {decision.reason_text}"
         log_graph_event(
             state,
             step=step,
@@ -122,7 +145,8 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
                 "policy_decision": decision.model_dump(),
             },
         )
-    elif decision.decision == PolicyDecisionValue.REQUIRE_APPROVAL:
+    elif decision.decision == PolicyDecisionValue.REQUIRE_CONFIRMATION:
+        step.confirmation_supplied = False
         existing = state.approval_records.get(step.approval_id or "")
         if existing and existing.is_approved:
             state.response = "Existing approval record found; validating before execution."
@@ -136,6 +160,8 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
             target_context=state.plan.target_context,
             approval_mode=decision.approval_mode,
             risk_tier=decision.risk_tier,
+            policy_snapshot_hash=step.policy_snapshot_hash or "",
+            step_binding=step_binding,
             authorized_outputs=state.authorized_step_outputs,
         )
         state.approval_records[approval.approval_id] = approval
@@ -148,8 +174,11 @@ def policy_node(state: AgentGraphState) -> AgentGraphState:
         phrase = approval.typed_confirmation_phrase
         step.confirmation_phrase = phrase
         state.pending_confirmation_phrase = phrase
+        confirmation_label = (
+            "admin confirmation" if decision.confirmation_type == "admin" else "user confirmation"
+        )
         state.response = (
-            "This action requires approval. "
+            f"This action requires {confirmation_label}. "
             f"Preview: {approval.preview.action_summary}; impacted target: "
             f"{approval.preview.impacted_target}. Please type: '{phrase}'"
         )

--- a/xfusion/policy/approval.py
+++ b/xfusion/policy/approval.py
@@ -41,6 +41,21 @@ def build_referenced_output_fingerprints(
     return fingerprints
 
 
+def build_step_binding(plan: ExecutionPlan, step: PlanStep) -> dict[str, Any]:
+    """Build deterministic step identity data bound into policy and approval fingerprints."""
+    step_index = next(
+        (index for index, candidate in enumerate(plan.steps) if candidate.step_id == step.step_id),
+        -1,
+    )
+    return {
+        "plan_id": plan.plan_id,
+        "step_id": step.step_id,
+        "step_index": step_index,
+        "depends_on": list(step.depends_on),
+        "repair_of_step_id": step.repair_of_step_id,
+    }
+
+
 def build_action_fingerprint(
     *,
     capability: CapabilityDefinition,
@@ -49,6 +64,9 @@ def build_action_fingerprint(
     target_context: dict[str, Any],
     approval_mode: ApprovalMode,
     risk_tier: RiskTier,
+    risk_contract: dict[str, Any] | None,
+    policy_snapshot_hash: str,
+    step_binding: dict[str, Any],
     referenced_output_fingerprints: dict[str, str],
     grouped_mutations: list[str] | None = None,
 ) -> str:
@@ -61,6 +79,9 @@ def build_action_fingerprint(
         "target_context": target_context,
         "approval_mode": approval_mode,
         "risk_tier": risk_tier,
+        "risk_contract": risk_contract or {},
+        "policy_snapshot_hash": policy_snapshot_hash,
+        "step_binding": step_binding,
         "referenced_output_fingerprints": referenced_output_fingerprints,
         "grouped_mutations": grouped_mutations or [capability.name],
     }
@@ -109,6 +130,8 @@ def create_approval_record(
     target_context: dict[str, Any],
     approval_mode: ApprovalMode,
     risk_tier: RiskTier,
+    policy_snapshot_hash: str,
+    step_binding: dict[str, Any],
     authorized_outputs: dict[str, dict[str, Any]],
     ttl_minutes: int = 10,
 ) -> ApprovalRecord:
@@ -124,10 +147,14 @@ def create_approval_record(
         target_context=target_context,
         approval_mode=approval_mode,
         risk_tier=risk_tier,
+        risk_contract=step.risk_contract,
+        policy_snapshot_hash=policy_snapshot_hash,
+        step_binding=step_binding,
         referenced_output_fingerprints=referenced_output_fingerprints,
     )
     approval_id = f"apr_{uuid4().hex[:12]}"
-    phrase = f"APPROVE {approval_id} {fingerprint[:12]}"
+    prefix = "ADMIN_APPROVE" if approval_mode == ApprovalMode.ADMIN else "APPROVE"
+    phrase = f"{prefix} {approval_id} {fingerprint[:12]}"
     preview = build_preview_payload(
         capability=capability,
         step=step,
@@ -143,6 +170,7 @@ def create_approval_record(
         normalized_capability_set=[capability.name],
         target_context=target_context,
         action_fingerprint=fingerprint,
+        policy_snapshot_hash=policy_snapshot_hash,
         referenced_output_fingerprints=referenced_output_fingerprints,
         approval_mode=approval_mode,
         risk_tier=risk_tier,
@@ -162,6 +190,9 @@ def validate_approval_for_invocation(
     target_context: dict[str, Any],
     approval_mode: ApprovalMode,
     risk_tier: RiskTier,
+    risk_contract: dict[str, Any] | None,
+    policy_snapshot_hash: str,
+    step_binding: dict[str, Any],
     argument_provenance: dict[str, str],
     referenced_output_fingerprints: dict[str, str],
 ) -> tuple[bool, str]:
@@ -176,8 +207,13 @@ def validate_approval_for_invocation(
         target_context=target_context,
         approval_mode=approval_mode,
         risk_tier=risk_tier,
+        risk_contract=risk_contract,
+        policy_snapshot_hash=policy_snapshot_hash,
+        step_binding=step_binding,
         referenced_output_fingerprints=referenced_output_fingerprints,
     )
     if current != approval.action_fingerprint:
         return False, "material_change"
+    if approval.policy_snapshot_hash != policy_snapshot_hash:
+        return False, "policy_snapshot_mismatch"
     return True, "approval_valid"

--- a/xfusion/policy/risk.py
+++ b/xfusion/policy/risk.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal
+
+from xfusion.domain.models.capability import CapabilityDefinition
+from xfusion.domain.models.environment import EnvironmentState
+from xfusion.domain.models.policy import StepRiskContract
+
+PolicyEffect = Literal["allow", "require_confirmation", "deny"]
+
+
+@dataclass(frozen=True)
+class RiskTraits:
+    """Deterministic traits extracted from capability+args for policy matching."""
+
+    command_family: str
+    read_only: bool
+    mutation: bool
+    cleanup_preview: bool
+    privilege_required: bool
+    filesystem_mutation: bool
+    process_control: bool
+    network_or_system_config_change: bool
+    data_destructive: bool
+    broad_impact: bool
+    unknown_risky_pattern: bool
+
+
+@dataclass(frozen=True)
+class RiskPolicyOutcome:
+    """Policy table result for one classified invocation."""
+
+    matched_rule_id: str
+    effect: PolicyEffect
+    risk_level: Literal["low", "medium", "high", "critical"]
+    reason: str
+    reason_codes: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class RiskPolicyRule:
+    """Explicit policy-table row for deterministic risk gating."""
+
+    rule_id: str
+    effect: PolicyEffect
+    risk_level: Literal["low", "medium", "high", "critical"]
+    reason: str
+    reason_codes: tuple[str, ...]
+
+
+RISK_POLICY_TABLE: tuple[RiskPolicyRule, ...] = (
+    RiskPolicyRule(
+        rule_id="risk.read_only.allow",
+        effect="allow",
+        risk_level="low",
+        reason="Read-only inspection is allowed within explicit scope.",
+        reason_codes=("read_only_allowed",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.cleanup_preview.allow",
+        effect="allow",
+        risk_level="low",
+        reason="Cleanup preview is read-only and bounded.",
+        reason_codes=("preview_allowed",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.unknown_pattern.deny",
+        effect="deny",
+        risk_level="critical",
+        reason="Invocation arguments contain an unknown risky command pattern.",
+        reason_codes=("unknown_risky_pattern", "deny_by_default"),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.broad_impact.deny",
+        effect="deny",
+        risk_level="critical",
+        reason="Broad-impact destructive action is denied.",
+        reason_codes=("broad_impact_destructive", "deny_by_default"),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.network_or_system_change.deny",
+        effect="deny",
+        risk_level="critical",
+        reason=(
+            "Network/system configuration mutations are denied unless "
+            "explicitly approved by policy."
+        ),
+        reason_codes=("network_or_system_change", "deny_by_default"),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.destructive.confirm",
+        effect="require_confirmation",
+        risk_level="high",
+        reason="Destructive mutation requires explicit admin confirmation.",
+        reason_codes=("destructive_requires_admin_confirmation",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.process_control.confirm",
+        effect="require_confirmation",
+        risk_level="high",
+        reason="Process-control mutation requires admin confirmation.",
+        reason_codes=("process_control_requires_admin_confirmation",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.privileged_mutation.confirm",
+        effect="require_confirmation",
+        risk_level="medium",
+        reason="Privileged bounded mutation requires explicit user confirmation.",
+        reason_codes=("privileged_mutation_requires_user_confirmation",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.filesystem_mutation.confirm",
+        effect="require_confirmation",
+        risk_level="medium",
+        reason="Filesystem mutation requires explicit confirmation.",
+        reason_codes=("filesystem_mutation_requires_confirmation",),
+    ),
+    RiskPolicyRule(
+        rule_id="risk.unclassified_mutation.deny",
+        effect="deny",
+        risk_level="critical",
+        reason="Unclassified mutation is denied by default.",
+        reason_codes=("unclassified_mutation", "deny_by_default"),
+    ),
+)
+
+
+def _is_truthy(value: object) -> bool:
+    return value is True
+
+
+def _detect_unknown_risky_pattern(args: dict[str, Any]) -> bool:
+    risky_tokens = (
+        "&&",
+        "||",
+        ";",
+        "`",
+        "$(",
+        "rm -rf",
+        "mkfs",
+        "dd if=",
+    )
+    for value in args.values():
+        if not isinstance(value, str):
+            continue
+        lowered = value.lower()
+        if any(token in lowered for token in risky_tokens):
+            return True
+    return False
+
+
+def classify_risk_traits(
+    *,
+    capability: CapabilityDefinition,
+    resolved_args: dict[str, Any],
+    environment: EnvironmentState,
+) -> RiskTraits:
+    """Classify deterministic risk traits from capability metadata and args."""
+    del environment  # Reserved for future environment-sensitive classification.
+
+    name = capability.name
+    family = name.split(".", 1)[0]
+    read_only = capability.is_read_only
+    cleanup_preview = name == "cleanup.safe_disk_cleanup" and not _is_truthy(
+        resolved_args.get("execute")
+    )
+    mutation = not read_only and not cleanup_preview
+
+    process_control = name in {"process.kill", "system.service_restart", "system.service_stop"}
+    filesystem_mutation = name in {
+        "cleanup.safe_disk_cleanup",
+        "file.write_file",
+        "file.delete",
+        "file.move",
+        "file.chmod",
+        "file.chown",
+    }
+    network_or_system_config_change = name in {
+        "system.package_install",
+        "system.firewall_update",
+        "system.route_update",
+        "system.config_write",
+    }
+    privilege_required = name in {
+        "process.kill",
+        "user.create",
+        "user.delete",
+        "cleanup.safe_disk_cleanup",
+    }
+
+    data_destructive = False
+    if name == "cleanup.safe_disk_cleanup" and _is_truthy(resolved_args.get("execute")):
+        data_destructive = True
+    if name == "process.kill" and str(resolved_args.get("signal", "TERM")).upper() in {
+        "TERM",
+        "KILL",
+    }:
+        data_destructive = True
+    if name == "user.delete":
+        data_destructive = True
+
+    broad_impact = False
+    all_paths: list[str] = []
+    for key in ("path",):
+        value = resolved_args.get(key)
+        if isinstance(value, str):
+            all_paths.append(value)
+    approved_paths = resolved_args.get("approved_paths")
+    if isinstance(approved_paths, list):
+        all_paths.extend(str(path) for path in approved_paths)
+    for path in all_paths:
+        lowered = path.strip().lower()
+        if lowered in {"/", "/*", "*", "/etc", "/usr", "/boot", "/var/lib"}:
+            broad_impact = True
+
+    unknown_risky_pattern = mutation and _detect_unknown_risky_pattern(resolved_args)
+
+    return RiskTraits(
+        command_family=family,
+        read_only=read_only,
+        mutation=mutation,
+        cleanup_preview=cleanup_preview,
+        privilege_required=privilege_required,
+        filesystem_mutation=filesystem_mutation,
+        process_control=process_control,
+        network_or_system_config_change=network_or_system_config_change,
+        data_destructive=data_destructive,
+        broad_impact=broad_impact,
+        unknown_risky_pattern=unknown_risky_pattern,
+    )
+
+
+def evaluate_risk_policy(traits: RiskTraits) -> RiskPolicyOutcome:
+    """Evaluate deterministic risk policy table and return one explicit decision."""
+    if traits.read_only:
+        rule = RISK_POLICY_TABLE[0]
+    elif traits.cleanup_preview:
+        rule = RISK_POLICY_TABLE[1]
+    elif traits.unknown_risky_pattern:
+        rule = RISK_POLICY_TABLE[2]
+    elif traits.broad_impact and traits.data_destructive:
+        rule = RISK_POLICY_TABLE[3]
+    elif traits.network_or_system_config_change:
+        rule = RISK_POLICY_TABLE[4]
+    elif traits.data_destructive:
+        rule = RISK_POLICY_TABLE[5]
+    elif traits.process_control:
+        rule = RISK_POLICY_TABLE[6]
+    elif traits.privilege_required:
+        rule = RISK_POLICY_TABLE[7]
+    elif traits.filesystem_mutation:
+        rule = RISK_POLICY_TABLE[8]
+    elif traits.mutation:
+        rule = RISK_POLICY_TABLE[9]
+    else:
+        # Unreachable for registered capabilities; fail closed if reached.
+        rule = RiskPolicyRule(
+            rule_id="risk.fail_closed",
+            effect="deny",
+            risk_level="critical",
+            reason="Unable to classify invocation risk deterministically.",
+            reason_codes=("risk_classification_failed", "deny_by_default"),
+        )
+
+    return RiskPolicyOutcome(
+        matched_rule_id=rule.rule_id,
+        effect=rule.effect,
+        risk_level=rule.risk_level,
+        reason=rule.reason,
+        reason_codes=rule.reason_codes,
+    )
+
+
+def build_risk_contract(
+    *,
+    traits: RiskTraits,
+    outcome: RiskPolicyOutcome,
+    deny_code: str | None = None,
+    deny_reason_text: str | None = None,
+) -> StepRiskContract:
+    """Construct the normalized per-step risk contract for audit/execution gating."""
+    side_effects: list[str] = []
+    if traits.read_only or traits.cleanup_preview:
+        side_effects.append("read_only_inspection")
+    if traits.filesystem_mutation:
+        side_effects.append("filesystem_mutation")
+    if traits.process_control:
+        side_effects.append("process_control")
+    if traits.network_or_system_config_change:
+        side_effects.append("network_or_system_config_change")
+    if traits.data_destructive:
+        side_effects.append("data_destructive")
+    if traits.privilege_required:
+        side_effects.append("privilege_escalation_required")
+    if traits.unknown_risky_pattern:
+        side_effects.append("unknown_risky_pattern")
+
+    if traits.read_only or traits.cleanup_preview:
+        reversibility = "reversible"
+    elif traits.data_destructive:
+        reversibility = "destructive"
+    else:
+        reversibility = "partially_reversible"
+
+    confirmation_type = "none"
+    if outcome.effect == "require_confirmation":
+        confirmation_type = "admin" if outcome.risk_level == "high" else "user"
+
+    return StepRiskContract(
+        risk_level=outcome.risk_level,
+        requires_confirmation=outcome.effect == "require_confirmation",
+        confirmation_type=confirmation_type,
+        deny_code=deny_code,
+        deny_reason_text=deny_reason_text,
+        deny_reason=deny_reason_text,
+        side_effects=sorted(set(side_effects)),
+        reversibility=reversibility,
+        privilege_required=traits.privilege_required,
+    )

--- a/xfusion/policy/rules.py
+++ b/xfusion/policy/rules.py
@@ -6,9 +6,23 @@ from xfusion.capabilities.registry import build_default_capability_registry
 from xfusion.domain.enums import ApprovalMode, PolicyDecisionValue, RiskTier
 from xfusion.domain.models.capability import CapabilityDefinition
 from xfusion.domain.models.environment import EnvironmentState
-from xfusion.domain.models.policy import PolicyDecision
+from xfusion.domain.models.policy import PolicyDecision, StepRiskContract
+from xfusion.policy.approval import stable_hash
 from xfusion.policy.protected_paths import is_protected
+from xfusion.policy.risk import (
+    build_risk_contract,
+    classify_risk_traits,
+    evaluate_risk_policy,
+)
 from xfusion.security.secrets import is_secret_path
+
+
+def _confirmation_type_for_mode(mode: ApprovalMode) -> str:
+    if mode == ApprovalMode.ADMIN:
+        return "admin"
+    if mode == ApprovalMode.HUMAN:
+        return "user"
+    return "none"
 
 
 def _decision(
@@ -19,10 +33,20 @@ def _decision(
     risk_tier: RiskTier,
     approval_mode: ApprovalMode,
     reason: str,
+    deny_code: str | None,
     reason_codes: list[str],
+    risk_contract: StepRiskContract | dict[str, object] | None = None,
     constraints_applied: list[str] | None = None,
     extra_explainability: dict[str, Any] | None = None,
 ) -> PolicyDecision:
+    risk_contract_payload_raw = (
+        risk_contract.model_dump() if isinstance(risk_contract, StepRiskContract) else risk_contract
+    )
+    risk_contract_payload = (
+        StepRiskContract.model_validate(risk_contract_payload_raw)
+        if isinstance(risk_contract_payload_raw, dict)
+        else risk_contract_payload_raw
+    )
     return PolicyDecision(
         decision=decision,
         matched_rule_id=matched_rule_id,
@@ -30,6 +54,8 @@ def _decision(
         approval_mode=approval_mode,
         constraints_applied=constraints_applied or [],
         reason_codes=reason_codes,
+        confirmation_type=_confirmation_type_for_mode(approval_mode),
+        deny_code=deny_code,
         explainability_record={
             "capability": capability.name if capability else None,
             "capability_version": capability.version if capability else None,
@@ -38,9 +64,12 @@ def _decision(
             "approval_mode": approval_mode,
             "decision": decision,
             "reason_codes": reason_codes,
+            "risk_contract": (risk_contract_payload.model_dump() if risk_contract_payload else {}),
             **(extra_explainability or {}),
         },
+        reason_text=reason,
         reason=reason,
+        risk_contract=risk_contract_payload,
     )
 
 
@@ -55,6 +84,37 @@ def _target_paths(args: dict[str, object]) -> list[str]:
     if isinstance(raw_paths, list):
         paths.extend(str(path) for path in raw_paths)
     return paths
+
+
+def build_policy_snapshot_payload(
+    *,
+    capability_name: str,
+    normalized_args: dict[str, object],
+    argument_provenance: dict[str, str],
+    decision: PolicyDecision,
+    environment: EnvironmentState,
+    step_binding: dict[str, object],
+) -> dict[str, object]:
+    """Return deterministic policy snapshot payload used for execute-time integrity checks."""
+    return {
+        "capability": capability_name,
+        "normalized_args": normalized_args,
+        "argument_provenance": argument_provenance,
+        "decision": decision.decision.value,
+        "matched_rule_id": decision.matched_rule_id,
+        "risk_tier": decision.risk_tier.value,
+        "approval_mode": decision.approval_mode.value,
+        "confirmation_type": decision.confirmation_type,
+        "deny_code": decision.deny_code,
+        "reason_codes": list(decision.reason_codes),
+        "risk_contract": decision.risk_contract.model_dump() if decision.risk_contract else {},
+        "environment": environment.model_dump(mode="json"),
+        "step_binding": step_binding,
+    }
+
+
+def build_policy_snapshot_hash(payload: dict[str, object]) -> str:
+    return stable_hash(payload)
 
 
 def evaluate_policy(
@@ -72,7 +132,7 @@ def evaluate_policy(
 ) -> PolicyDecision:
     """Return the v0.2 deterministic policy decision for a capability invocation.
 
-    This function is authoritative for allow/require_approval/deny decisions
+    This function is authoritative for allow/require_confirmation/deny decisions
     and defaults to deny when invocation inputs or matching rules are unclear.
     """
     if not capability_name:
@@ -83,7 +143,19 @@ def evaluate_policy(
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
             reason="Missing required capability name for policy evaluation.",
+            deny_code="invalid_policy_invocation",
             reason_codes=["invalid_policy_invocation", "deny_by_default"],
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "invalid_policy_invocation",
+                "deny_reason_text": "Missing required capability name for policy evaluation.",
+                "deny_reason": "Missing required capability name for policy evaluation.",
+                "side_effects": [],
+                "reversibility": "destructive",
+                "privilege_required": False,
+            },
         )
     if resolved_args is None:
         return _decision(
@@ -93,7 +165,19 @@ def evaluate_policy(
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
             reason="Missing required resolved args for policy evaluation.",
+            deny_code="invalid_policy_invocation",
             reason_codes=["invalid_policy_invocation", "deny_by_default"],
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "invalid_policy_invocation",
+                "deny_reason_text": "Missing required resolved args for policy evaluation.",
+                "deny_reason": "Missing required resolved args for policy evaluation.",
+                "side_effects": [],
+                "reversibility": "destructive",
+                "privilege_required": False,
+            },
         )
 
     name = capability_name
@@ -109,7 +193,19 @@ def evaluate_policy(
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
             reason=f"Unknown capability '{name}' is denied by default.",
+            deny_code="unknown_capability",
             reason_codes=["unknown_capability", "deny_by_default"],
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "unknown_capability",
+                "deny_reason_text": f"Unknown capability '{name}' is denied by default.",
+                "deny_reason": f"Unknown capability '{name}' is denied by default.",
+                "side_effects": ["unknown_capability"],
+                "reversibility": "destructive",
+                "privilege_required": False,
+            },
         )
 
     if actor_type not in capability.allowed_actor_types:
@@ -120,7 +216,23 @@ def evaluate_policy(
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
             reason=f"Actor type '{actor_type}' is not allowed for capability '{name}'.",
+            deny_code="actor_type_not_allowed",
             reason_codes=["actor_type_not_allowed"],
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "actor_type_not_allowed",
+                "deny_reason_text": (
+                    f"Actor type '{actor_type}' is not allowed for capability '{name}'."
+                ),
+                "deny_reason": (
+                    f"Actor type '{actor_type}' is not allowed for capability '{name}'."
+                ),
+                "side_effects": [],
+                "reversibility": "destructive",
+                "privilege_required": False,
+            },
         )
 
     for path in _target_paths(args):
@@ -132,7 +244,19 @@ def evaluate_policy(
                 risk_tier=RiskTier.TIER_3,
                 approval_mode=ApprovalMode.DENY,
                 reason=f"Path '{path}' is known secret material and is denied.",
+                deny_code="secret_path",
                 reason_codes=["secret_path", "secret_denied"],
+                risk_contract={
+                    "risk_level": "critical",
+                    "requires_confirmation": False,
+                    "confirmation_type": "none",
+                    "deny_code": "secret_path",
+                    "deny_reason_text": f"Path '{path}' is known secret material and is denied.",
+                    "deny_reason": f"Path '{path}' is known secret material and is denied.",
+                    "side_effects": ["secret_material_access"],
+                    "reversibility": "destructive",
+                    "privilege_required": False,
+                },
             )
         if is_protected(path, environment.protected_paths) and not capability.is_read_only:
             return _decision(
@@ -142,20 +266,45 @@ def evaluate_policy(
                 risk_tier=RiskTier.TIER_3,
                 approval_mode=ApprovalMode.DENY,
                 reason=f"Path '{path}' is protected and cannot be modified.",
+                deny_code="protected_path",
                 reason_codes=["protected_path", "scope_violation"],
+                risk_contract={
+                    "risk_level": "critical",
+                    "requires_confirmation": False,
+                    "confirmation_type": "none",
+                    "deny_code": "protected_path",
+                    "deny_reason_text": f"Path '{path}' is protected and cannot be modified.",
+                    "deny_reason": f"Path '{path}' is protected and cannot be modified.",
+                    "side_effects": ["filesystem_mutation", "data_destructive"],
+                    "reversibility": "destructive",
+                    "privilege_required": True,
+                },
             )
 
     if target_scope != "explicit":
+        scope_reason = (
+            f"Capability '{name}' requires explicit target scope; received '{target_scope}'."
+        )
         return _decision(
             decision=PolicyDecisionValue.DENY,
             matched_rule_id="scope.explicit_required",
             capability=capability,
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
-            reason=(
-                f"Capability '{name}' requires explicit target scope; received '{target_scope}'."
-            ),
+            reason=scope_reason,
+            deny_code="scope_not_explicit",
             reason_codes=["scope_not_explicit", "deny_by_default"],
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "scope_not_explicit",
+                "deny_reason_text": scope_reason,
+                "deny_reason": scope_reason,
+                "side_effects": [],
+                "reversibility": "destructive",
+                "privilege_required": False,
+            },
             extra_explainability={
                 "target_scope": target_scope,
                 "request_intent": request_intent,
@@ -166,92 +315,99 @@ def evaluate_policy(
     if name == "plan.explain_action":
         path = str(args.get("path", "the requested path"))
         action = str(args.get("action", "action"))
+        permission_reason = (
+            f"Recursive {action} permission changes on protected path '{path}' are forbidden."
+        )
         return _decision(
             decision=PolicyDecisionValue.DENY,
             matched_rule_id="protected_path.recursive_permission_change.deny",
             capability=capability,
             risk_tier=RiskTier.TIER_3,
             approval_mode=ApprovalMode.DENY,
-            reason=(
-                f"Recursive {action} permission changes on protected path '{path}' are forbidden."
-            ),
+            reason=permission_reason,
+            deny_code="permission_change_forbidden",
             reason_codes=["protected_path", "permission_change_forbidden"],
-        )
-
-    if capability.risk_tier == RiskTier.TIER_3 or capability.approval_mode == ApprovalMode.DENY:
-        return _decision(
-            decision=PolicyDecisionValue.DENY,
-            matched_rule_id="tier3.deny",
-            capability=capability,
-            risk_tier=RiskTier.TIER_3,
-            approval_mode=ApprovalMode.DENY,
-            reason=f"Capability '{name}' is prohibited or broad impact.",
-            reason_codes=["tier_3_denied"],
-        )
-
-    if capability.risk_tier == RiskTier.TIER_0 and capability.is_read_only:
-        return _decision(
-            decision=PolicyDecisionValue.ALLOW,
-            matched_rule_id="tier0.read_only.explicit_scope.allow",
-            capability=capability,
-            risk_tier=RiskTier.TIER_0,
-            approval_mode=ApprovalMode.AUTO,
-            constraints_applied=["explicit_scope", "read_only", "network_denied"],
-            reason="Tier 0 read-only capability is allowed within explicit scope.",
-            reason_codes=["tier_0_read_only_allowed"],
-            extra_explainability={
-                "argument_provenance": argument_provenance or {},
-                "host_class": host_class,
-                "target_scope": target_scope,
-                "request_intent": request_intent,
+            risk_contract={
+                "risk_level": "critical",
+                "requires_confirmation": False,
+                "confirmation_type": "none",
+                "deny_code": "permission_change_forbidden",
+                "deny_reason_text": permission_reason,
+                "deny_reason": permission_reason,
+                "side_effects": ["filesystem_mutation", "data_destructive"],
+                "reversibility": "destructive",
+                "privilege_required": True,
             },
         )
 
-    if capability.risk_tier == RiskTier.TIER_1:
-        if name == "cleanup.safe_disk_cleanup" and args.get("execute") is not True:
-            return _decision(
-                decision=PolicyDecisionValue.ALLOW,
-                matched_rule_id="tier1.cleanup_preview.allow",
-                capability=capability,
-                risk_tier=RiskTier.TIER_0,
-                approval_mode=ApprovalMode.AUTO,
-                constraints_applied=["preview_only", "bounded_candidates", "network_denied"],
-                reason="Cleanup preview is read-only and bounded to approved candidates.",
-                reason_codes=["preview_allowed"],
-            )
-        return _decision(
-            decision=PolicyDecisionValue.REQUIRE_APPROVAL,
-            matched_rule_id="tier1.mutation.human_approval",
-            capability=capability,
-            risk_tier=RiskTier.TIER_1,
-            approval_mode=ApprovalMode.HUMAN,
-            constraints_applied=["explicit_target", "human_approval_required", "network_denied"],
-            reason=f"Capability '{name}' is a bounded mutation and requires human approval.",
-            reason_codes=["tier_1_requires_human_approval"],
-            extra_explainability={
-                "prior_approval_state": prior_approval_state or {},
-                "time_quota_context": time_quota_context or {},
-            },
-        )
+    traits = classify_risk_traits(
+        capability=capability,
+        resolved_args=args,
+        environment=environment,
+    )
+    risk_eval = evaluate_risk_policy(traits)
+    deny_code = risk_eval.reason_codes[0] if risk_eval.effect == "deny" else None
+    deny_reason_text = risk_eval.reason if risk_eval.effect == "deny" else None
+    risk_contract = build_risk_contract(
+        traits=traits,
+        outcome=risk_eval,
+        deny_code=deny_code,
+        deny_reason_text=deny_reason_text,
+    ).model_dump()
 
-    if capability.risk_tier == RiskTier.TIER_2:
-        return _decision(
-            decision=PolicyDecisionValue.REQUIRE_APPROVAL,
-            matched_rule_id="tier2.mutation.admin_approval",
-            capability=capability,
-            risk_tier=RiskTier.TIER_2,
-            approval_mode=ApprovalMode.ADMIN,
-            constraints_applied=["admin_approval_required", "explicit_scope"],
-            reason=f"Capability '{name}' is high risk and requires admin approval.",
-            reason_codes=["tier_2_requires_admin_approval"],
-        )
+    decision_map = {
+        "allow": PolicyDecisionValue.ALLOW,
+        "require_confirmation": PolicyDecisionValue.REQUIRE_CONFIRMATION,
+        "deny": PolicyDecisionValue.DENY,
+    }
+    tier_map = {
+        "low": RiskTier.TIER_0,
+        "medium": RiskTier.TIER_1,
+        "high": RiskTier.TIER_2,
+        "critical": RiskTier.TIER_3,
+    }
+    approval_mode = ApprovalMode.DENY
+    if risk_eval.effect == "allow":
+        approval_mode = ApprovalMode.AUTO
+    elif risk_eval.effect == "require_confirmation":
+        approval_mode = ApprovalMode.ADMIN if risk_eval.risk_level == "high" else ApprovalMode.HUMAN
+
+    constraints = ["explicit_scope", "network_denied"]
+    if risk_eval.effect == "require_confirmation":
+        constraints.append("step_bound_typed_confirmation")
+    if risk_eval.risk_level == "high":
+        constraints.append("admin_confirmation_required")
 
     return _decision(
-        decision=PolicyDecisionValue.DENY,
-        matched_rule_id="default.fail_closed",
+        decision=decision_map[risk_eval.effect],
+        matched_rule_id=risk_eval.matched_rule_id,
         capability=capability,
-        risk_tier=RiskTier.TIER_3,
-        approval_mode=ApprovalMode.DENY,
-        reason=f"No exact policy rule matched capability '{name}'.",
-        reason_codes=["no_exact_rule", "deny_by_default"],
+        risk_tier=tier_map[risk_eval.risk_level],
+        approval_mode=approval_mode,
+        constraints_applied=constraints,
+        reason=risk_eval.reason,
+        deny_code=deny_code,
+        reason_codes=list(risk_eval.reason_codes),
+        risk_contract=risk_contract,
+        extra_explainability={
+            "argument_provenance": argument_provenance or {},
+            "host_class": host_class,
+            "target_scope": target_scope,
+            "request_intent": request_intent,
+            "command_family": traits.command_family,
+            "risk_traits": {
+                "read_only": traits.read_only,
+                "mutation": traits.mutation,
+                "cleanup_preview": traits.cleanup_preview,
+                "privilege_required": traits.privilege_required,
+                "filesystem_mutation": traits.filesystem_mutation,
+                "process_control": traits.process_control,
+                "network_or_system_config_change": traits.network_or_system_config_change,
+                "data_destructive": traits.data_destructive,
+                "broad_impact": traits.broad_impact,
+                "unknown_risky_pattern": traits.unknown_risky_pattern,
+            },
+            "prior_approval_state": prior_approval_state or {},
+            "time_quota_context": time_quota_context or {},
+        },
     )


### PR DESCRIPTION
## v0.2.4: What Shipped

This PR ships the focused v0.2.4 hardening increment while preserving the deterministic, fail-closed, registered-capability model.

### Implemented
- Normalized machine-readable policy fields:
  - `decision`: `allow | require_confirmation | deny`
  - `confirmation_type`: `none | user | admin`
  - `deny_code`
  - `reason_text` (human-readable)
- Normalized non-execution fields:
  - `non_execution.code`
  - `non_execution.reason_text`
- Explicit `high` risk behavior:
  - `high -> require_confirmation (admin)`
  - `medium -> require_confirmation (user)`
  - `critical -> deny`
- Execute-time integrity hardening:
  - policy recheck on execution
  - step policy snapshot hashing
  - fail-closed on integrity mismatch (`policy_integrity_mismatch`)
- Approval binding hardening:
  - fingerprint now binds policy snapshot hash and deterministic step binding
  - blocks replay/reuse across plan mutation/reorder/state drift
- Audit decision chain updates:
  - `policy_decision_code`, `confirmation_type`, `deny_code`, normalized `non_execution`
- Adversarial and regression tests expanded for stale state / tampering / drift.

## What Intentionally Did Not Change
- No arbitrary shell passthrough.
- No broad semantic planner.
- No capability-surface expansion beyond registered commands.
- No physical runtime/container sandbox redesign.

## Known Limitations (Tracked Separately)
These are intentionally deferred and **not blockers for v0.2.4 release**:

- Identity-bound admin authorization is not yet implemented: #11
- Policy-table coverage/environment profiling is still compact: #12
- Adversarial replay/tamper corpus needs broader expansion: #13
- Runtime isolation remains declarative (not OS-level sandbox): #14
- Equivalent-repair approval reuse still uses simple gating path: #15
- Repair pattern library is intentionally narrow: #16
- Role boundaries are not physically isolated: #17
- Optional signed audit snapshots are not yet implemented: #18

## Release Decision Statement
Deferred hardening is tracked by separate GitHub issues above and is intentionally out of scope for v0.2.4.
This PR remains cohesive, deterministic, and release-ready for tag `v0.2.4`.
